### PR TITLE
Add cleanup action

### DIFF
--- a/.github/workflows/cleanup_branches.yml
+++ b/.github/workflows/cleanup_branches.yml
@@ -13,9 +13,10 @@ jobs:
         with:
           github_token: ${{ secrets.TEST_APPSWAY_TOKEN }}
           last_commit_age_days: 15
+          ignore_branches: GUI_terminal_sound,GUI_tests,GUI_working_sound,appRobotinterfaceOnly,fixUserDeployCleanup,importLocalfolder
 
           # Disable dry run and actually get stuff deleted
-          dry_run: yes
+          dry_run: no
 
       - name: Get output
         run: "echo 'Deleted branches: ${{ steps.delete_stuff.outputs.deleted_branches }}'"

--- a/.github/workflows/cleanup_branches.yml
+++ b/.github/workflows/cleanup_branches.yml
@@ -11,7 +11,7 @@ jobs:
         uses: phpdocker-io/github-actions-delete-abandoned-branches@v1
         id: delete_stuff
         with:
-          github_token: ${{ secrets.CODE_REPO_ACCSS_TOKEN }}
+          github_token: ${{ secrets.TEST_APPSWAY_TOKEN }}
           last_commit_age_days: 15
 
           # Disable dry run and actually get stuff deleted

--- a/.github/workflows/cleanup_branches.yml
+++ b/.github/workflows/cleanup_branches.yml
@@ -11,7 +11,7 @@ jobs:
         uses: phpdocker-io/github-actions-delete-abandoned-branches@v1
         id: delete_stuff
         with:
-          github_token: ${{ secrets.TEST_APPSWAY_TOKEN }}
+          github_token: ${{ github.token }}
           last_commit_age_days: 15
           ignore_branches: GUI_terminal_sound,GUI_tests,GUI_working_sound,appRobotinterfaceOnly,fixUserDeployCleanup,importLocalfolder
 

--- a/.github/workflows/cleanup_branches.yml
+++ b/.github/workflows/cleanup_branches.yml
@@ -1,7 +1,10 @@
 name: Cleanup dead branches
 
-on: workflow_dispatch
-
+on:
+  schedule:
+  # * is a special character in YAML so you have to quote this string
+  # Execute a "nightly" build at 2 AM UTC
+  - cron:  '0 2 * * *'
 jobs:
   cleanup_old_branches:
     runs-on: ubuntu-latest

--- a/.github/workflows/cleanup_branches.yml
+++ b/.github/workflows/cleanup_branches.yml
@@ -1,11 +1,6 @@
 name: Cleanup dead branches
 
-on: 
-  workflow_dispatch
-  schedule:
-  # * is a special character in YAML so you have to quote this string
-  # Execute a "nightly" build at 2 AM UTC
-  - cron:  '0 2 * * *'
+on: workflow_dispatch
 
 jobs:
   cleanup_old_branches:

--- a/.github/workflows/cleanup_branches.yml
+++ b/.github/workflows/cleanup_branches.yml
@@ -16,7 +16,6 @@ jobs:
         with:
           github_token: ${{ github.token }}
           last_commit_age_days: 15
-          ignore_branches: GUI_terminal_sound,GUI_tests,GUI_working_sound,appRobotinterfaceOnly,fixUserDeployCleanup,importLocalfolder
 
           # Disable dry run and actually get stuff deleted
           dry_run: no

--- a/.github/workflows/cleanup_branches.yml
+++ b/.github/workflows/cleanup_branches.yml
@@ -1,0 +1,26 @@
+name: Cleanup dead branches
+
+on: 
+  workflow_dispatch
+  schedule:
+  # * is a special character in YAML so you have to quote this string
+  # Execute a "nightly" build at 2 AM UTC
+  - cron:  '0 2 * * *'
+
+jobs:
+  cleanup_old_branches:
+    runs-on: ubuntu-latest
+    name: Satisfy my repo CDO
+    steps:
+      - name: Delete those pesky dead branches
+        uses: phpdocker-io/github-actions-delete-abandoned-branches@v1
+        id: delete_stuff
+        with:
+          github_token: ${{ secrets.CODE_REPO_ACCSS_TOKEN }}
+          last_commit_age_days: 15
+
+          # Disable dry run and actually get stuff deleted
+          dry_run: yes
+
+      - name: Get output
+        run: "echo 'Deleted branches: ${{ steps.delete_stuff.outputs.deleted_branches }}'"


### PR DESCRIPTION
This action remove all branches inactive in the last 15 days, I put some branches in the whitelist because I don't know what they contain.

I use this GA -> https://github.com/phpdocker-io/github-actions-delete-abandoned-branches

And I don't know if we need a specific token, on my fork it worked See https://github.com/Nicogene/appsAway that it has just 11 branches