### PR TITLE
Triggering the testing pipeline 

### DIFF
--- a/.github/workflows/onAppsAwayChanges.yml
+++ b/.github/workflows/onAppsAwayChanges.yml
@@ -1,0 +1,53 @@
+# this workflow will generate the containers on push. These containers are for test only, so ideally they should be uploaded to a private repo, not available to the public. tag=superbuild_devel (?)
+# for the stable versions, use superbuild_builder_stable.yml, triggered on release
+
+name: onAppsawayChanges
+
+on: 
+    push:
+        paths:
+            - 'demos/**'
+
+jobs:
+
+    check_files:
+      runs-on: ubuntu-latest
+      steps: 
+      - id: file_changes
+        uses: trilom/file-changes-action@v1.2.3
+      - name: files
+        run: |
+          cat $HOME/files.json
+          cat $HOME/files_modified.json
+          cat $HOME/files_added.json
+          echo '${{ steps.file_changes.outputs.files}}'
+          echo '${{ steps.file_changes.outputs.files_modified}}'
+          echo '${{ steps.file_changes.outputs.files_added}}'
+      - name: find demo name
+        id: set_app_list
+        run: |
+          parsed_list=($(echo '${{ steps.file_changes.outputs.files}}' | tr ',' '\n'))
+          app_name_list=""
+          iter_app_list=0
+          for i in "${parsed_list[@]}"
+          do 
+            if [ $(echo $i | awk '/demos/') ]
+            then
+              app_name=$(echo $i | awk -F'/' '{print $2}' | tr -d '"')
+              if [ $iter_app_list == 0 ]
+              then 
+                app_name_list="$app_name"
+                iter_app_list=$(($iter_app_list+1))
+              else
+                app_name_list="$app_name_list $app_name"
+              fi
+            fi
+          done
+          echo "::set-output name=apps::${app_name_list[@]}"
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.CODE_ACCESS_TOKEN }}
+          repository: icub-tech-iit/code
+          event-type: app_testing
+          client-payload: '{"type": "app_testing",  "app_list": "${{ steps.set_app_list.outputs.apps}}"}'

--- a/demos/cameraTiltCalib/composeGui.yml
+++ b/demos/cameraTiltCalib/composeGui.yml
@@ -30,13 +30,11 @@ services:
   #Opening the viewer to see the left output image
   yview_right_img_o:
     <<: *yarp-base
-    container_name: yview_output_l
     command: yarpview --name /leftImageOutput
 
   #Opening we open the viewer to see the right output image
   yview_left_img_o:
     <<: *yarp-base
-    container_name: yview_output_r
     command: yarpview --name /rightImageOutput
 
 

--- a/demos/cameraTiltCalib/composeHead.yml
+++ b/demos/cameraTiltCalib/composeHead.yml
@@ -19,7 +19,6 @@ services:
     <<: *yarp-base
     devices: 
       - "/dev/video0:/dev/video0"
-    container_name: yGrabberCameras
     command: sh -c "if [ -z ${LEFT_CUSTOM_PORT} && -z ${RIGHT_CUSTOM_PORT} ]; then yarpdev --from camera/ServerGrabberDualDragon.ini --split true; fi"
 
 

--- a/demos/demoTemplate/composeHead.yml.template
+++ b/demos/demoTemplate/composeHead.yml.template
@@ -19,7 +19,6 @@ services:
     <<: *yarp-head
     devices: 
       - "/dev/bosch-i2c-imu:/dev/bosch-i2c-imu"
-    container_name: yrobotinterface
     command: yarprobotinterface
 
 #################################### ADD YOUR SERVICES HERE #####################################

--- a/demos/faceAndPoseDetection/composeGui.yml
+++ b/demos/faceAndPoseDetection/composeGui.yml
@@ -22,18 +22,15 @@ services:
 
   ylogger:
     <<: *yarp-base
-    container_name: ylogger
     command: yarplogger --start
 
 #following services are configured in ./icub-main/app/default/scripts/cameras_calib.xml.template
   yview_pose:
     <<: *yarp-base
-    container_name: yview_l
     command: yarpview --name /pose --x 0 --y 0 --p 50 --w 320 --h 240
 
   yview_image:
     <<: *yarp-base
-    container_name: yview_r
     command: yarpview --name /view/input_image --x 320 --y 0 --p 50 --w 320 --h 240
 
 

--- a/demos/faceAndPoseDetection/composeHead.yml
+++ b/demos/faceAndPoseDetection/composeHead.yml
@@ -21,7 +21,6 @@ services:
     <<: *yarp-head
     devices: 
       - "/dev/video0:/dev/video0"
-    container_name: yGrabberCameras
     command: sh -c "if [ -z ${CUSTOM_PORT} ]; then yarpdev --from camera/ServerGrabberDualDragon.ini --split true; fi" 
 
 

--- a/demos/googleDialog/composeGui.yml
+++ b/demos/googleDialog/composeGui.yml
@@ -36,7 +36,6 @@ services:
     <<: *yarp-base
     devices: 
       - "/dev/snd:/dev/snd"
-    container_name: yMicrophone
     command: sh -c "yarp wait /root; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --rate 16000 --samples 16000"
 
   yDemoGoogleSynthesis:

--- a/demos/googleDialog/main.yml
+++ b/demos/googleDialog/main.yml
@@ -70,7 +70,6 @@ services:
   
   yconnect_audio:
     <<: *yarp-base
-    container_name: yconnect_audio
     deploy:
       restart_policy:
         condition: on-failure
@@ -78,7 +77,6 @@ services:
 
   yconnect_rpc:
     <<: *yarp-base
-    container_name: yconnect_rpc
     deploy:
       restart_policy:
         condition: on-failure

--- a/demos/googleSpeechApp/composeGui.yml
+++ b/demos/googleSpeechApp/composeGui.yml
@@ -36,7 +36,6 @@ services:
     <<: *yarp-base
     devices: 
       - "/dev/snd:/dev/snd"
-    container_name: yMicrophone
     command: sh -c "if [ ${GOOGLE_INPUT} = 'True' ]; then yarp wait /root; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --rate 16000 --samples 16000; fi;"
 
   yDemoGoogleSynthesis:

--- a/demos/googleSpeechApp/main.yml
+++ b/demos/googleSpeechApp/main.yml
@@ -74,7 +74,6 @@ services:
 
   yconnect_audio:
     <<: *yarp-base
-    container_name: yconnect_audio
     deploy:
       restart_policy:
         condition: on-failure
@@ -82,7 +81,6 @@ services:
 
   yconnect_rpc:
     <<: *yarp-base
-    container_name: yconnect_rpc
     deploy:
       restart_policy:
         condition: on-failure

--- a/demos/googleSpeechProcessing/composeGui.yml
+++ b/demos/googleSpeechProcessing/composeGui.yml
@@ -27,19 +27,16 @@ services:
     <<: *yarp-base
     devices: 
       - "/dev/snd:/dev/snd"
-    container_name: yMicrophone
     command: sh -c "yarp wait /root; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --rate 16000 --samples 16000"
   
   yconnect_audio:
     <<: *yarp-base
-    container_name: yconnect_audio
     depends_on:
       - yMicrophone
     command: sh -c "yarp wait /microphone/audio:o; yarp wait /googleSpeech/sound:i; yarp connect /microphone/audio:o /googleSpeech/sound:i tcp"
 
   yconnect_rpc:
     <<: *yarp-base
-    container_name: yconnect_rpc
     depends_on:
       - yMicrophone
     command: sh -c "yarp wait /microphone/rpc; yarp wait /googleSpeech/commands:rpc; yarp connect /googleSpeech/commands:rpc /microphone/rpc tcp"

--- a/demos/googleVisionAI/composeGui.yml
+++ b/demos/googleVisionAI/composeGui.yml
@@ -28,27 +28,23 @@ services:
     <<: *yarp-base
     devices: 
       - "/dev/video0:/dev/video0"
-    container_name: yGrabberCameras
     command: sh -c "if [ -z ${CUSTOM_PORT} ]; then yarpdev --from camera/ServerGrabberDualDragon.ini --split true; fi" 
 
 #------------------------------------------------------------------------------------------------
   #Here we open the viewer to see the output image
   yview_image_o:
     <<: *yarp-base
-    container_name: yview_o
     command: yarpview --name /outImage 
 
   #Here we open the viewer to see icub view
   yview_icub_l:
     <<: *yarp-base
-    container_name: yview_icub_l
     command: sh -c "if [ -z ${CUSTOM_PORT} ]; then yarpview --name  /icub/view/left; fi"
   
 
   #Here we open the viewer to see the input of the custom port
   yview_port_image_i:
     <<: *yarp-base
-    container_name: yview_port_input
     command: yarpview --name /startImage 
 
 

--- a/demos/graspTheBall/composeGui.yml
+++ b/demos/graspTheBall/composeGui.yml
@@ -22,23 +22,19 @@ services:
 
   ylogger:
     <<: *yarp-base
-    container_name: ylogger
     command: yarplogger --start
 
 #following services are configured in ./icub-main/app/default/scripts/cameras_calib.xml.template
   yview_l:
     <<: *yarp-base
-    container_name: yview_l
     command: yarpview --name /icub/view/left --x 0 --y 0 --p 50 --w 320 --h 240
 
   yview_r:
     <<: *yarp-base
-    container_name: yview_r
     command: yarpview --name /icub/view/right --x 320 --y 0 --p 50 --w 320 --h 240
 
   yconnect_l:
     <<: *yarp-base
-    container_name: yconnect_l
     depends_on:
       - yview
     command: sh -c "yarp wait /icub/camcalib/left/out; yarp wait /icub/view/left; yarp connect /icub/camcalib/left/out /icub/view/left fast_tcp"
@@ -46,7 +42,6 @@ services:
 
   yconnect_r:
     <<: *yarp-base
-    container_name: yconnect_r
     depends_on:
       - yview
     command: sh -c "yarp wait /icub/camcalib/right/out; yarp wait /icub/view/right; yarp connect /icub/camcalib/right/out /icub/view/right fast_tcp"
@@ -56,12 +51,10 @@ services:
 #Following services are configured in icub-basic-demos/demoRedBall/app/scripts/demoRedBall.xml.template
   yview:
     <<: *yarp-base
-    container_name: yview_demo
     command: yarpview --name /PF3DTracker_viewer --x 320 --y 0 --p 50 --compact
 
   yconnect_demo:
     <<: *yarp-base
-    container_name: yconnect_demo
     depends_on:
       - yview
     command: sh -c "yarp wait /pf3dTracker/video:o; yarp wait /PF3DTracker_viewer; yarp connect /pf3dTracker/video:o /PF3DTracker_viewer fast_tcp"

--- a/demos/graspTheBall/composeHead.yml
+++ b/demos/graspTheBall/composeHead.yml
@@ -20,14 +20,12 @@ services:
     <<: *yarp-head
     devices: 
       - "/dev/bosch-i2c-imu:/dev/bosch-i2c-imu"
-    container_name: yrobotinterface
     command: yarprobotinterface
 
   yGrabberCameras:
     <<: *yarp-head
     devices: 
       - "/dev/video0:/dev/video0"
-    container_name: yGrabberCameras
     command: sh -c "yarpdev --from camera/ServerGrabberDualDragon.ini --split true"
     #command: sh -c "yarpdev --device usbCamera --d /dev/video0 --camModel leopard_python --name /icub/cam/left"
 

--- a/demos/graspTheBallGazebo/composeGui.yml
+++ b/demos/graspTheBallGazebo/composeGui.yml
@@ -31,18 +31,15 @@ services:
 
   ygazebo:
     <<: *yarp-gazebo
-    container_name: ygazebo
     command: sh -c "sleep 10; gazebo grasp-ball-gazebo.sdf --verbose"
 
 #following services are configured in ./icub-main/app/default/scripts/cameras_calib.xml.template
   yview_l:
     <<: *yarp-gazebo
-    container_name: yview_l
     command: yarpview --name /icubSim/view/left --x 0 --y 0 --p 50 --compact
 
   yview_r:
     <<: *yarp-gazebo
-    container_name: yview_r
     command: yarpview --name /icubSim/view/right --x 400 --y 0 --p 50 --compact
 
 
@@ -50,6 +47,5 @@ services:
 #Following services are configured in icub-basic-demos/demoRedBall/app/scripts/demoRedBall.xml.template
   yview:
     <<: *yarp-gazebo
-    container_name: yview_demo
     command: yarpview --name /PF3DTracker_viewer --x 750 --y 0 --p 50 --compact
 

--- a/demos/iCubGazeboGrasping/composeGui.yml
+++ b/demos/iCubGazeboGrasping/composeGui.yml
@@ -38,22 +38,18 @@ services:
 
   find-superquadric:
     <<: *yarp-base
-    container_name: find-superquadric
     command: sh -c "yarp wait /view/left; find-superquadric --remove-outliers '(0.01 10)' --random-sample 0.2 --disable-viewer"
 
   yview:
     <<: *yarp-base
-    container_name: yview
     command: yarpview --name /view/left --compact --p 10 --x 20 --y 20
 
   icub-gazebo-grasping-sandbox:
     <<: *yarp-base
-    container_name: icub-gazebo-grasping-sandbox
     command: sh -c "yarp wait /iKinGazeCtrl/rpc; yarp wait /icubSim/cartesianController/right_arm/state:o; yarp wait /icubSim/cartesianController/left_arm/state:o; icub-gazebo-grasping-sandbox"
 
 #  icub-gazebo-grasping-sandbox:
 #    <<: *yarp-base
-#    container_name: icub-gazebo-grasping-sandbox
 #    depends_on:
 #      - yrobotinterface
 #    command: sh -c "yarp wait /icubSim/torso/state:o ; yarp wait /icubSim/left_arm/state:o ; yarp wait /icubSim/right_arm/state:o ; ( yarprobotinterface --context gazeboCartesianControl --config no_legs.xml & ) ; checkRobotInterface --robot icubSim ; yarp wait /icubSim/torso/state:o ; yarp wait /icubSim/right_arm/state:o ; ( iKinCartesianSolver --context gazeboCartesianControl --part right_arm & ) ; yarp wait /icubSim/torso/state:o ; yarp wait /icubSim/left_arm/state:o ; ( iKinCartesianSolver --context gazeboCartesianControl --part left_arm & ) ; yarp wait /icubSim/torso/state:o ; yarp wait /icubSim/head/state:o ; yarp wait /icubSim/inertial ; (iKinGazeCtrl --context gazeboCartesianControl --from iKinGazeCtrl.ini &) ; yarp wait /iKinGazeCtrl/rpc; yarp wait /icubSim/cartesianController/right_arm/state:o; yarp wait /icubSim/cartesianController/left_arm/state:o; sleep 20; icub-gazebo-grasping-sandbox"

--- a/demos/iCubGazeboGrasping/main.yml
+++ b/demos/iCubGazeboGrasping/main.yml
@@ -37,7 +37,6 @@ services:
 
   yrobotinterface:
     <<: *yarp-base
-    container_name: yrobotinterface
     command: sh -c "yarp wait /icubSim/torso/state:o; yarp wait /icubSim/head/state:o; yarp wait /icubSim/left_arm/state:o; yarp wait /icubSim/right_arm/state:o; sleep 10; yarprobotinterface --context gazeboCartesianControl --config no_legs.xml "
 #    command: sh -c " yarp wait /icubSim/torso/state:o ; yarp wait /icubSim/left_arm/state:o ; yarp wait /icubSim/right_arm/state:o ; ( yarprobotinterface --context gazeboCartesianControl --config no_legs.xml & ) ; checkRobotInterface --robot icubSim ; yarp wait /icubSim/torso/state:o ; yarp wait /icubSim/right_arm/state:o ; ( iKinCartesianSolver --context gazeboCartesianControl --part right_arm & ) ; yarp wait /icubSim/torso/state:o ; yarp wait /icubSim/left_arm/state:o ; ( iKinCartesianSolver --context gazeboCartesianControl --part left_arm & ) ; yarp wait /icubSim/torso/state:o ; yarp wait /icubSim/head/state:o ; yarp wait /icubSim/inertial ; iKinGazeCtrl --context gazeboCartesianControl --from iKinGazeCtrl.ini"
 
@@ -46,28 +45,24 @@ services:
 
   iKinCartesianSolver_r:
     <<: *yarp-base
-    container_name: iKinCartesianSolver_r
     depends_on:
       - yrobotinterface
     command: sh -c "yarp wait /icubSim/torso/state:o; yarp wait /icubSim/right_arm/state:o; sleep 10; iKinCartesianSolver --context gazeboCartesianControl --part right_arm"
 
   iKinCartesianSolver_l:
     <<: *yarp-base
-    container_name: iKinCartesianSolver_l
     depends_on:
       - yrobotinterface
     command: sh -c "yarp wait /icubSim/torso/state:o; yarp wait /icubSim/left_arm/state:o; sleep 10; iKinCartesianSolver --context gazeboCartesianControl --part left_arm"
 
   iKinGazeCtrl:
     <<: *yarp-base
-    container_name: iKinGazeCtrl
     depends_on:
       - yrobotinterface
     command: sh -c "yarp wait /icubSim/torso/state:o; yarp wait /icubSim/head/state:o; yarp wait /icubSim/inertial; sleep 10; iKinGazeCtrl --context gazeboCartesianControl --from iKinGazeCtrl.ini"
 
 #  connect-world:
 #    <<: *yarp-base
-#    container_name: connect-world
 #    depends_on:
 #      - yrobotinterface
 #    deploy:
@@ -77,7 +72,6 @@ services:
 
   connect-mustard:
     <<: *yarp-base
-    container_name: connect-mustard
     depends_on:
       - yrobotinterface
     deploy:
@@ -87,7 +81,6 @@ services:
 
   connect-pudding:
     <<: *yarp-base
-    container_name: connect-pudding
     depends_on:
       - yrobotinterface
     deploy:
@@ -97,7 +90,6 @@ services:
 
   connect-view:
     <<: *yarp-base
-    container_name: connect-view
     depends_on:
       - yrobotinterface
     deploy:
@@ -107,7 +99,6 @@ services:
 
   connect-rgb:
     <<: *yarp-base
-    container_name: connect-rgb
     depends_on:
       - yrobotinterface
     deploy:
@@ -117,7 +108,6 @@ services:
 
   connect-depth:
     <<: *yarp-base
-    container_name: connect-depth
     depends_on:
       - yrobotinterface
     deploy:
@@ -127,7 +117,6 @@ services:
 
   connect-superquadric:
     <<: *yarp-base
-    container_name: connect-superquadric
     depends_on:
       - yrobotinterface
     deploy:
@@ -137,7 +126,6 @@ services:
 
 #  icub-gazebo-grasping-sandbox:
 #    <<: *yarp-base
-#    container_name: icub-gazebo-grasping-sandbox
 #    depends_on:
 #      - yrobotinterface
 #    command: sh -c "yarp wait /iKinGazeCtrl/rpc; yarp wait /icubSim/cartesianController/right_arm/state:o; yarp wait /icubSim/cartesianController/left_arm/state:o; icub-gazebo-grasping-sandbox"

--- a/demos/robotBaseStartup/composeHead.yml
+++ b/demos/robotBaseStartup/composeHead.yml
@@ -20,7 +20,6 @@ services:
     <<: *yarp-head
     devices: 
       - "/dev/bosch-i2c-imu:/dev/bosch-i2c-imu"
-    container_name: yrobotinterface
     command: yarprobotinterface
 
 

--- a/demos/robotGazebo/test-script.sh
+++ b/demos/robotGazebo/test-script.sh
@@ -1,0 +1,118 @@
+function check_failure { #TODO: we can't give a script as input to the function (unless the script is returning something...)
+    "$@"
+    local status=$?
+    if (( status != 0 ))
+    then
+        echo "error with $1" >&2
+        failure_counter=$(($failure_counter+1))
+        echo "Failure counter: $failure_counter"
+    fi
+}
+
+function setupEnvironment {
+        cd $HOME/teamcode/appsAway/demos/$APPSAWAY_APP_NAME
+        yml_files_default=("main.yml" "composeGui.yml")
+        yml_files_default_len=${#yml_files_default[@]}
+        yml_files=()
+
+        for (( i=0; i<$yml_files_default_len; i++ ))
+        do
+          if [ -f "${yml_files_default[$i]}" ]
+          then
+            yml_files+=(${yml_files_default[$i]})
+          fi
+        done
+        for (( i=0; i<${#yml_files[@]}; i++ ))
+        do  
+            if [[ $APPSAWAY_IMAGES != '' ]] 
+            then
+                list_images=($APPSAWAY_IMAGES)
+                list_versions=($APPSAWAY_VERSIONS)
+                list_tags=($APPSAWAY_TAGS)
+            fi
+            for (( j=0; j<${#list_images[@]}; j++ ))
+            do
+                sed -i 's,image: '"${list_images[$j]}"'.*$,image: '"${list_images[$j]}"':'"${list_versions[$j]}"'_'"${list_tags[$j]}"',g' ${yml_files[$i]}
+            done
+            # while read -r line || [ -n "$line" ]
+            # do
+              
+
+            # done < ${yml_files[$i]} 
+        done
+      
+
+        # # env file is located in iCubApps folder, so we need APPSAWAY_APP_PATH
+        # os.chdir(os.environ.get('APPSAWAY_APP_PATH'))
+
+        # env_file = open(".env", "r")
+        # env_list = env_file.read().split('\n')
+        # env_file.close()
+
+        # # Checking if we already have all the environment variables in the .env; if yes we overwrite them, if not we add them 
+        # for button in self.button_list:
+        #   not_found = True
+        #   not_found_path = True
+        #   for i in range(len(env_list)):
+        #     if button.varType == 'fileInput':
+        #       if env_list[i].find(button.varName + "_PATH=") != -1 and os.environ.get(button.varName + "_PATH") != None:
+        #         env_list[i] = button.varName + "_PATH=" + os.environ.get(button.varName + "_PATH")
+        #         not_found_path = False
+        #     if env_list[i].find(button.varName + "=") != -1 and os.environ.get(button.varName) != None:
+        #       env_list[i] = button.varName + "=" + os.environ.get(button.varName)
+        #       not_found = False
+        #   if not_found and os.environ.get(button.varName) != None:
+        #     env_list.insert(len(env_list), button.varName + "=" + os.environ.get(button.varName))
+        #   if not_found_path and os.environ.get(button.varName + "_PATH") != None:
+        #     env_list.insert(len(env_list), button.varName + "_PATH=" + os.environ.get(button.varName + "_PATH"))
+
+
+        # env_file = open(".env", "w")
+        # for line in env_list:
+        #   env_file.write(line + '\n')
+        # env_file.close()
+
+        # os.chdir(os.path.join(os.environ.get('HOME'), "teamcode","appsAway","scripts"))
+          
+        # # now we copy all the files to their respective machines
+        cd $HOME/teamcode/appsAway/scripts
+}
+
+
+failure_counter=0
+
+cd $HOME/teamcode/appsAway/scripts
+echo "#! /bin/bash
+export APPSAWAY_APP_NAME=$1
+export APPSAWAY_USER_NAME=runner
+export APPSAWAY_APP_PATH=\${HOME}/iCubApps/\${APPSAWAY_APP_NAME}
+export APPSAWAY_CONSOLENODE_ADDR=$2
+export APPSAWAY_CONSOLENODE_USERNAME=runner
+export APPSAWAY_IMAGES=\"icubteamcode/superbuild-gazebo\"
+export APPSAWAY_VERSIONS=\"master-unstable_master\"
+export APPSAWAY_TAGS=\"binaries\"
+export APPSAWAY_DEPLOY_YAML_FILE_LIST=main.yml
+export APPSAWAY_GUI_YAML_FILE_LIST=composeGui.yml
+export APPSAWAY_STACK_NAME=mystack
+export APPSAWAY_NODES_NAME_LIST=\"console\" 
+export APPSAWAY_NODES_ADDR_LIST=\"\${APPSAWAY_GUINODE_ADDR} \${APPSAWAY_ICUBHEADNODE_ADDR} \${APPSAWAY_CONSOLENODE_ADDR} \${APPSAWAY_CUDANODE_ADDR} \${APPSAWAY_WORKERNODE_ADDR}\" 
+export APPSAWAY_NODES_USERNAME_LIST=\"\${APPSAWAY_GUINODE_USERNAME} \${APPSAWAY_ICUBHEADNODE_USERNAME} \${APPSAWAY_CONSOLENODE_USERNAME} \${APPSAWAY_CUDANODE_USERNAME} \${APPSAWAY_WORKERNODE_USERNAME}\" " > ./appsAway_setEnvironment.local.sh 
+chmod +x appsAway_setEnvironment.local.sh
+source ./appsAway_setEnvironment.local.sh
+ 
+echo "about to setup the cluster..." 
+./appsAway_setupCluster.sh
+./appsAway_setupSwarm.sh
+setupEnvironment
+./appsAway_copyFiles.sh
+check_failure ./appsAway_startApp.sh
+sleep 30
+check_failure ./testApp.sh $APPSAWAY_APP_NAME $APPSAWAY_STACK_NAME
+./appsAway_stopApp.sh 
+
+
+if (( $failure_counter > 0 )) 
+then 
+    echo "Some commands failed"
+    exit 1
+fi

--- a/demos/speechToText/composeGui.yml
+++ b/demos/speechToText/composeGui.yml
@@ -27,19 +27,16 @@ services:
     <<: *yarp-base
     devices: 
       - "/dev/snd:/dev/snd"
-    container_name: yMicrophone
     command: sh -c "yarp wait /root; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --rate 16000 --samples 16000"
   
   yconnect_audio:
     <<: *yarp-base
-    container_name: yconnect_audio
     depends_on:
       - yMicrophone
     command: sh -c "yarp wait /microphone/audio:o; yarp wait /googleSpeech/sound:i; yarp connect /microphone/audio:o /googleSpeech/sound:i tcp"
 
   yconnect_rpc:
     <<: *yarp-base
-    container_name: yconnect_rpc
     depends_on:
       - yMicrophone
     command: sh -c "yarp wait /microphone/rpc; yarp wait /googleSpeech/commands:rpc; yarp connect /googleSpeech/commands:rpc /microphone/rpc tcp"

--- a/demos/startQA/composeGui.yml
+++ b/demos/startQA/composeGui.yml
@@ -28,19 +28,16 @@ services:
     <<: *yarp-base
     devices: 
       - "/dev/snd:/dev/snd"
-    container_name: yMicrophone
     command: sh -c "yarp wait /root; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --rate 16000 --samples 16000"
   
   yconnect_audio:
     <<: *yarp-base
-    container_name: yconnect_audio
     depends_on:
       - yMicrophone
     command: sh -c "yarp wait /microphone/audio:o; yarp wait /googleSpeech/sound:i; yarp connect /microphone/audio:o /googleSpeech/sound:i tcp"
 
   yconnect_rpc:
     <<: *yarp-base
-    container_name: yconnect_rpc
     depends_on:
       - yMicrophone
     command: sh -c "yarp wait /microphone/rpc; yarp wait /googleSpeech/commands:rpc; yarp connect /googleSpeech/commands:rpc /microphone/rpc tcp"

--- a/demos/superviseCalib/composeGui.yml
+++ b/demos/superviseCalib/composeGui.yml
@@ -25,42 +25,35 @@ services:
   #Opening we open the viewer to see the raw left camera
   yview_left:
     <<: *yarp-base
-    container_name: yview_left
     command: yarpview --name /viewer/left --x 635 --y 0
 
   #Opening we open the viewer to see the raw right camera
   yview_right:
     <<: *yarp-base
-    container_name: yview_right
     command: yarpview --name /viewer/right --x 940 --y 0
 
   #Opening the viewer to see the display of calibSupervisor
   yview_calib_display:
     <<: *yarp-base
-    container_name: yview_calib_display
     command: yarpview --name /display --x 0 --y 0 --w 550 --h 550
 
   #Opening we open the viewer to see the output of calibSupervisor
   #yview_calib_output:
   #  <<: *yarp-base
-  #  container_name: yview_calib_output
   #  command: yarpview --name /sendtocalib
 
   #Opening we open the viewer to see the left output of camCalib after calibration
   yview_camcalib_left:
     <<: *yarp-base
-    container_name: yview_camcalib_left
     command: yarpview --name /viewer_calib/left --x 635 --y 400
 
   #Opening we open the viewer to see the right output of camCalib after calibration
   yview_camcalib_right:
     <<: *yarp-base
-    container_name: yview_camcalib_right
     command: yarpview --name /viewer_calib/right --x 940 --y 400
 
   #Opening we open the viewer to see the template during calibration
   yview_template:
     <<: *yarp-base
-    container_name: yview_template
     command: yarpview --name /viewer_template --x 0 --y 650 --w 450 --h 450
 

--- a/demos/superviseCalib/composeHead.yml
+++ b/demos/superviseCalib/composeHead.yml
@@ -20,14 +20,12 @@ services:
     <<: *yarp-head
     devices: 
       - "/dev/video0:/dev/video0"
-    container_name: yGrabberCameras
     command: sh -c "yarpdev --from camera/ServerGrabberDualDragon.ini --split true; "
 
   yrobotinterface:
     <<: *yarp-head
     devices: 
       - "/dev/bosch-i2c-imu:/dev/bosch-i2c-imu"
-    container_name: yrobotinterface
     command: yarprobotinterface
 
 

--- a/demos/yarpBasicDeploy/composeGui.yml
+++ b/demos/yarpBasicDeploy/composeGui.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-gui
-  image: icubteamcode/superbuild:v2020.05_binaries
+  image: icubteamcode/superbuild:master-unstable_master_binaries
   environment:
     - DISPLAY=${DISPLAY}
     - QT_X11_NO_MITSHM=1
@@ -21,12 +21,10 @@ services:
 
   yview:
     <<: *yarp-gui
-    container_name: yview
     command: yarpview --name /view --x 0 --y 0 --p 50
    
   yconnect_demo:
     <<: *yarp-gui
-    container_name: yconnect_demo
     depends_on:
       - yview
     command: sh -c "yarp wait /grabber; yarp wait /view; yarp connect /grabber /view tcp"

--- a/demos/yarpBasicDeploy/composeHead.yml
+++ b/demos/yarpBasicDeploy/composeHead.yml
@@ -17,6 +17,5 @@ services:
 
     ynamelist:
         <<: *yarp-head
-        container_name: ynamelist
         command: yarp name list
           

--- a/demos/yarpBasicDeploy/main.yml
+++ b/demos/yarpBasicDeploy/main.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/superbuild:v2020.05_binaries
+  image: icubteamcode/superbuild:master-unstable_master_binaries
   environment:
     - DISPLAY=${DISPLAY}
     - QT_X11_NO_MITSHM=1
@@ -24,7 +24,7 @@ services:
           constraints: [node.role == manager]
         restart_policy:
           condition: on-failure
-    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --write; fi"
+      command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --write; fi"
 
     ydevice:
       <<: *yarp-base

--- a/demos/yarpBasicDeploy/test-script.sh
+++ b/demos/yarpBasicDeploy/test-script.sh
@@ -1,0 +1,118 @@
+function check_failure { #TODO: we can't give a script as input to the function (unless the script is returning something...)
+    "$@"
+    local status=$?
+    if (( status != 0 ))
+    then
+        echo "error with $1" >&2
+        failure_counter=$(($failure_counter+1))
+        echo "Failure counter: $failure_counter"
+    fi
+}
+
+function setupEnvironment {
+        cd $HOME/teamcode/appsAway/demos/$APPSAWAY_APP_NAME
+        yml_files_default=("main.yml" "composeGui.yml")
+        yml_files_default_len=${#yml_files_default[@]}
+        yml_files=()
+
+        for (( i=0; i<$yml_files_default_len; i++ ))
+        do
+          if [ -f "${yml_files_default[$i]}" ]
+          then
+            yml_files+=(${yml_files_default[$i]})
+          fi
+        done
+        for (( i=0; i<${#yml_files[@]}; i++ ))
+        do  
+            if [[ $APPSAWAY_IMAGES != '' ]] 
+            then
+                list_images=($APPSAWAY_IMAGES)
+                list_versions=($APPSAWAY_VERSIONS)
+                list_tags=($APPSAWAY_TAGS)
+            fi
+            for (( j=0; j<${#list_images[@]}; j++ ))
+            do
+                sed -i 's,image: '"${list_images[$j]}"'.*$,image: '"${list_images[$j]}"':'"${list_versions[$j]}"'_'"${list_tags[$j]}"',g' ${yml_files[$i]}
+            done
+            # while read -r line || [ -n "$line" ]
+            # do
+              
+
+            # done < ${yml_files[$i]} 
+        done
+      
+
+        # # env file is located in iCubApps folder, so we need APPSAWAY_APP_PATH
+        # os.chdir(os.environ.get('APPSAWAY_APP_PATH'))
+
+        # env_file = open(".env", "r")
+        # env_list = env_file.read().split('\n')
+        # env_file.close()
+
+        # # Checking if we already have all the environment variables in the .env; if yes we overwrite them, if not we add them 
+        # for button in self.button_list:
+        #   not_found = True
+        #   not_found_path = True
+        #   for i in range(len(env_list)):
+        #     if button.varType == 'fileInput':
+        #       if env_list[i].find(button.varName + "_PATH=") != -1 and os.environ.get(button.varName + "_PATH") != None:
+        #         env_list[i] = button.varName + "_PATH=" + os.environ.get(button.varName + "_PATH")
+        #         not_found_path = False
+        #     if env_list[i].find(button.varName + "=") != -1 and os.environ.get(button.varName) != None:
+        #       env_list[i] = button.varName + "=" + os.environ.get(button.varName)
+        #       not_found = False
+        #   if not_found and os.environ.get(button.varName) != None:
+        #     env_list.insert(len(env_list), button.varName + "=" + os.environ.get(button.varName))
+        #   if not_found_path and os.environ.get(button.varName + "_PATH") != None:
+        #     env_list.insert(len(env_list), button.varName + "_PATH=" + os.environ.get(button.varName + "_PATH"))
+
+
+        # env_file = open(".env", "w")
+        # for line in env_list:
+        #   env_file.write(line + '\n')
+        # env_file.close()
+
+        # os.chdir(os.path.join(os.environ.get('HOME'), "teamcode","appsAway","scripts"))
+          
+        # # now we copy all the files to their respective machines
+        cd $HOME/teamcode/appsAway/scripts
+}
+
+
+failure_counter=0
+
+cd $HOME/teamcode/appsAway/scripts
+echo "#! /bin/bash
+export APPSAWAY_APP_NAME=$1
+export APPSAWAY_USER_NAME=runner
+export APPSAWAY_APP_PATH=\${HOME}/iCubApps/\${APPSAWAY_APP_NAME}
+export APPSAWAY_CONSOLENODE_ADDR=$2
+export APPSAWAY_CONSOLENODE_USERNAME=runner
+export APPSAWAY_IMAGES=\"icubteamcode/superbuild\"
+export APPSAWAY_VERSIONS=\"master-unstable_master\"
+export APPSAWAY_TAGS=\"binaries\"
+export APPSAWAY_DEPLOY_YAML_FILE_LIST=main.yml
+export APPSAWAY_GUI_YAML_FILE_LIST=composeGui.yml
+export APPSAWAY_STACK_NAME=mystack
+export APPSAWAY_NODES_NAME_LIST=\"console\" 
+export APPSAWAY_NODES_ADDR_LIST=\"\${APPSAWAY_GUINODE_ADDR} \${APPSAWAY_ICUBHEADNODE_ADDR} \${APPSAWAY_CONSOLENODE_ADDR} \${APPSAWAY_CUDANODE_ADDR} \${APPSAWAY_WORKERNODE_ADDR}\" 
+export APPSAWAY_NODES_USERNAME_LIST=\"\${APPSAWAY_GUINODE_USERNAME} \${APPSAWAY_ICUBHEADNODE_USERNAME} \${APPSAWAY_CONSOLENODE_USERNAME} \${APPSAWAY_CUDANODE_USERNAME} \${APPSAWAY_WORKERNODE_USERNAME}\" " > ./appsAway_setEnvironment.local.sh 
+chmod +x appsAway_setEnvironment.local.sh
+source ./appsAway_setEnvironment.local.sh
+ 
+echo "about to setup the cluster..." 
+./appsAway_setupCluster.sh
+./appsAway_setupSwarm.sh
+setupEnvironment
+./appsAway_copyFiles.sh
+check_failure ./appsAway_startApp.sh
+sleep 30
+check_failure ./testApp.sh $APPSAWAY_APP_NAME $APPSAWAY_STACK_NAME
+./appsAway_stopApp.sh 
+
+
+if (( $failure_counter > 0 )) 
+then 
+    echo "Some commands failed"
+    exit 1
+fi

--- a/demos/yarpOpenFace/composeGui.yml
+++ b/demos/yarpOpenFace/composeGui.yml
@@ -23,23 +23,19 @@ services:
 
   ylogger:
     <<: *yarp-base
-    container_name: ylogger
     command: yarplogger --start
 
 #following services are configured in ./icub-main/app/default/scripts/cameras_calib.xml.template
   yview_l:
     <<: *yarp-base
-    container_name: yview_l
     command: sh -c "yarpview --name /icub/view/left --x 0 --y 0 --p 50"
 
   yview_r:
     <<: *yarp-base
-    container_name: yview_r
     command: sh -c "yarpview --name /icub/view/right --x 450 --y 0 --p 50"
 
   yconnect_l:
     <<: *yarp-base
-    container_name: yconnect_l
     depends_on:
       - yview
     command: sh -c "yarp wait /icub/camcalib/left/out; yarp wait /icub/view/left; yarp connect /icub/camcalib/left/out /icub/view/left udp"
@@ -47,7 +43,6 @@ services:
 
   yconnect_r:
     <<: *yarp-base
-    container_name: yconnect_r
     depends_on:
       - yview
     command: sh -c "yarp wait /icub/camcalib/right/out; yarp wait /icub/view/right; yarp connect /icub/camcalib/right/out /icub/view/right udp"
@@ -55,7 +50,6 @@ services:
 
   yframeGrabberGui_l:
     <<: *yarp-base
-    container_name: yframeGrabberGui_l
     command: sh -c "yarp wait /icub/cam/left; frameGrabberGui2 --local /icub/fggui/left --remote /icub/cam/left --x 800 --y 0 --width 350 --height 500"
 
 
@@ -65,12 +59,10 @@ services:
 #Following services are configured in icub-basic-demos/demoRedBall/app/scripts/demoRedBall.xml.template 
   yview:
     <<: *yarp-base
-    container_name: yview_demo
     command: sh -c "yarpview --name /faceDetector_viewer --x 450 --y 400 --p 50"
 
   yconnect_demo:
     <<: *yarp-base
-    container_name: yconnect_demo
     depends_on:
       - yview
     command: sh -c "yarp wait /yarpOpenFace/outputImg:o; yarp wait /faceDetector_viewer; yarp connect /yarpOpenFace/outputImg:o /faceDetector_viewer udp"

--- a/demos/yarpOpenFace/composeHead.yml
+++ b/demos/yarpOpenFace/composeHead.yml
@@ -21,13 +21,11 @@ services:
     <<: *yarp-head
     devices: 
       - "/dev/bosch-i2c-imu:/dev/bosch-i2c-imu"
-    container_name: yrobotinterface
     command: yarprobotinterface
 
   yGrabberCameras:
     <<: *yarp-head
     devices: 
       - "/dev/video0:/dev/video0"
-    container_name: yGrabberCameras
     command: sh -c "if [ -z ${CUSTOM_PORT} ]; then yarpdev --from camera/ServerGrabberDualDragon.ini --split true; fi"
 

--- a/scripts/testApp.sh
+++ b/scripts/testApp.sh
@@ -1,0 +1,18 @@
+#! /bin/bash
+# Getting the lines containing failed containers
+failed_containers=$(docker ps -a --filter 'exited=1'| grep -i $1)
+failed_containers+=$(docker ps -a --filter 'exited=1'| grep -i $2)
+# Getting the name of failed containers
+container_names=($(echo $failed_containers | tr ' ' '\n' | grep -i $1) $(echo $failed_containers | tr ' ' '\n' | grep -i $2))
+filtered_container_names=(${container_names[@]/*[cC]onnect/})
+for i in "${filtered_container_names[@]}"
+do
+    echo "Fetching logs from container name: $i" 
+    docker logs $i 
+done
+if [[ ${#filtered_container_names[@]} != 0 ]]
+then
+    exit 1
+fi
+
+


### PR DESCRIPTION
With @lauracavaliere and @AlexAntn, we introduced the following changes:
- a github action called `onAppsawayChanges`, which sends a repository dispatch to code when there are changes to the deployments files;
- a `testApp.sh` script in `appsAway/scripts`, which checks if there are any failed containers and eventually prints the log;
- for `yarpBasicDeploy` and `robotGazebo` a `test-script.sh`, which emulates the cluster setup pipeline from the website. 

The `test-script.sh` is currently specific for each demo, as it includes the specific image to be tested. This script then runs the `testApp.sh` script which is generic. 

This PR should be merged after the [PR](https://github.com/icub-tech-iit/code/pull/629) on code, such that it will trigger the pipeline.