### PR TITLE
Handle the testing pipeline triggered from code

### DIFF
--- a/.github/workflows/onAppsAwayChanges.yml
+++ b/.github/workflows/onAppsAwayChanges.yml
@@ -51,5 +51,5 @@ jobs:
         with:
           token: ${{ secrets.CODE_REPO_ACCSS_TOKEN }}
           repository: icub-tech-iit/code
-          event-type: app_testing
-          client-payload: '{"type": "app_testing",  "app_list": "${{ steps.set_app_list.outputs.apps}}"}'
+          event-type: app_testing_from_appsaway
+          client-payload: '{"type": "app_testing_from_appsaway",  "app_list": "${{ steps.set_app_list.outputs.apps}}"}'

--- a/demos/robotGazebo/main.yml
+++ b/demos/robotGazebo/main.yml
@@ -1,5 +1,6 @@
 version: "3.7"
 
+
 x-yarp-base: &yarp-base
   image: icubteamcode/superbuild-gazebo:master-unstable_sources  
   environment:

--- a/demos/robotGazebo/test-script.sh
+++ b/demos/robotGazebo/test-script.sh
@@ -81,6 +81,8 @@ function setupEnvironment {
 
 failure_counter=0
 
+echo "Passed parameters: $1 $2 $3 $4 $5 $6" 
+
 cd $HOME/teamcode/appsAway/scripts
 echo "#! /bin/bash
 export APPSAWAY_APP_NAME=$1
@@ -88,9 +90,9 @@ export APPSAWAY_USER_NAME=icub
 export APPSAWAY_APP_PATH=\${HOME}/iCubApps/\${APPSAWAY_APP_NAME}
 export APPSAWAY_CONSOLENODE_ADDR=$2
 export APPSAWAY_CONSOLENODE_USERNAME=icub
-export APPSAWAY_IMAGES=\"icubteamcode/superbuild-gazebo\"
-export APPSAWAY_VERSIONS=\"master-unstable_master\"
-export APPSAWAY_TAGS=\"binaries\"
+export APPSAWAY_IMAGES=${3:-\"icubteamcode/superbuild-gazebo\"}
+export APPSAWAY_VERSIONS=${4:-\"master-unstable_master\"}  
+export APPSAWAY_TAGS=${5:-\"binaries\"} 
 export APPSAWAY_DEPLOY_YAML_FILE_LIST=main.yml
 export APPSAWAY_GUI_YAML_FILE_LIST=composeGui.yml
 export APPSAWAY_STACK_NAME=mystack
@@ -99,6 +101,10 @@ export APPSAWAY_NODES_ADDR_LIST=\"\${APPSAWAY_GUINODE_ADDR} \${APPSAWAY_ICUBHEAD
 export APPSAWAY_NODES_USERNAME_LIST=\"\${APPSAWAY_GUINODE_USERNAME} \${APPSAWAY_ICUBHEADNODE_USERNAME} \${APPSAWAY_CONSOLENODE_USERNAME} \${APPSAWAY_CUDANODE_USERNAME} \${APPSAWAY_WORKERNODE_USERNAME}\" " > ./appsAway_setEnvironment.local.sh 
 chmod +x appsAway_setEnvironment.local.sh
 source ./appsAway_setEnvironment.local.sh
+
+echo "images: $APPSAWAY_IMAGES"
+echo "versions: $APPSAWAY_VERSIONS"
+echo "tags: $APPSAWAY_TAGS"
  
 echo "about to setup the cluster..." 
 ./appsAway_setupCluster.sh
@@ -110,6 +116,12 @@ sleep 30
 check_failure ./testApp.sh $APPSAWAY_APP_NAME $APPSAWAY_STACK_NAME
 ./appsAway_stopApp.sh 
 
+CHILDREN_FLAG=${6:-true}
+if [ $CHILDREN_FLAG == false ]
+then
+  echo "Removing $APPSAWAY_IMAGES:$APPSAWAY_VERSIONS\_$APPSAWAY_TAGS"
+  docker image rm -f $APPSAWAY_IMAGES:$APPSAWAY_VERSIONS\_$APPSAWAY_TAGS
+fi
 
 if (( $failure_counter > 0 )) 
 then 

--- a/demos/yarpBasicDeploy/test-script.sh
+++ b/demos/yarpBasicDeploy/test-script.sh
@@ -88,9 +88,9 @@ export APPSAWAY_USER_NAME=icub
 export APPSAWAY_APP_PATH=\${HOME}/iCubApps/\${APPSAWAY_APP_NAME}
 export APPSAWAY_CONSOLENODE_ADDR=$2
 export APPSAWAY_CONSOLENODE_USERNAME=icub
-export APPSAWAY_IMAGES=\"icubteamcode/superbuild\"
-export APPSAWAY_VERSIONS=\"master-unstable_master\"
-export APPSAWAY_TAGS=\"binaries\"
+export APPSAWAY_IMAGES=${3:-\"icubteamcode/superbuild\"}
+export APPSAWAY_VERSIONS=${4-\"master-unstable_master\"}
+export APPSAWAY_TAGS=${5-\"binaries\"}
 export APPSAWAY_DEPLOY_YAML_FILE_LIST=main.yml
 export APPSAWAY_GUI_YAML_FILE_LIST=composeGui.yml
 export APPSAWAY_STACK_NAME=mystack
@@ -100,6 +100,10 @@ export APPSAWAY_NODES_USERNAME_LIST=\"\${APPSAWAY_GUINODE_USERNAME} \${APPSAWAY_
 chmod +x appsAway_setEnvironment.local.sh
 source ./appsAway_setEnvironment.local.sh
  
+echo "images: $APPSAWAY_IMAGES"
+echo "versions: $APPSAWAY_VERSIONS"
+echo "tags: $APPSAWAY_TAGS"
+
 echo "about to setup the cluster..." 
 ./appsAway_setupCluster.sh
 ./appsAway_setupSwarm.sh
@@ -110,6 +114,12 @@ sleep 30
 check_failure ./testApp.sh $APPSAWAY_APP_NAME $APPSAWAY_STACK_NAME
 ./appsAway_stopApp.sh 
 
+CHILDREN_FLAG=${6:-true}
+if [ $CHILDREN_FLAG == false ]
+then
+  echo "Removing $APPSAWAY_IMAGES:$APPSAWAY_VERSIONS\_$APPSAWAY_TAGS"
+  docker image rm -f $APPSAWAY_IMAGES:$APPSAWAY_VERSIONS\_$APPSAWAY_TAGS
+fi
 
 if (( $failure_counter > 0 )) 
 then 


### PR DESCRIPTION
This PR introduces the following changes:
- `test-script.sh` was updated to handle the **image name / version / tag** coming from `appsAway` or `code:`
    -  if coming from `appsAway,`  the **image name / version / tag** are the default values defined in the script;
    - if coming from `code,` the **image name / version / tag** are extracted from the `client-payload.`