### PR TITLE
Update cleanup_branches.yml

### DIFF
--- a/.github/workflows/cleanup_branches.yml
+++ b/.github/workflows/cleanup_branches.yml
@@ -11,7 +11,7 @@ jobs:
     name: Satisfy my repo CDO
     steps:
       - name: Delete those pesky dead branches
-        uses: phpdocker-io/github-actions-delete-abandoned-branches@v1
+        uses: phpdocker-io/github-actions-delete-abandoned-branches@master
         id: delete_stuff
         with:
           github_token: ${{ github.token }}


### PR DESCRIPTION
Since phpdocker-io/github-actions-delete-abandoned-branches#7 has been merged, maybe it is better to use the fixed version of the action, that now check all over the branches and not a limited number