### PR TITLE
Handling local images inside the pipeline

### DIFF
--- a/demos/yarpBasicDeploy/composeGui.yml
+++ b/demos/yarpBasicDeploy/composeGui.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-gui
-  image: icubteamcode/superbuild:master-unstable_master_binaries
+  image: localhost:5000/superbuild-test
   environment:
     - DISPLAY=${DISPLAY}
     - QT_X11_NO_MITSHM=1

--- a/demos/yarpBasicDeploy/gui/gui_conf.ini
+++ b/demos/yarpBasicDeploy/gui/gui_conf.ini
@@ -5,5 +5,9 @@ title "YARP Basic Demo"
 ImageName "images/yarpview.png"
  
 [right options]
+toggleButton "" "Local image" LOCAL_IMAGE_FLAG true/false on unticked
+textEditBox "Specify Local image" "" LOCAL_IMAGE_NAME None on None
 
+[Button hierarchy]
+Dependency - LOCAL_IMAGE_NAME - ( {LOCAL_IMAGE_FLAG selected enable} )
 

--- a/demos/yarpBasicDeploy/main.yml
+++ b/demos/yarpBasicDeploy/main.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/superbuild:master-unstable_master_binaries
+  image: localhost:5000/superbuild-test
   environment:
     - DISPLAY=${DISPLAY}
     - QT_X11_NO_MITSHM=1

--- a/gui/main.py
+++ b/gui/main.py
@@ -636,7 +636,8 @@ class WidgetGallery(QDialog):
         elapsedTime.start()
 
         self.startApplication()
-
+        os.chdir(os.path.join(os.environ.get('HOME'),"teamcode","appsAway","scripts"))
+        rc = subprocess.call("./appsAway_setEnvironment.local.sh")
             
     def stopProgressBar(self):
         self.pushStopButton.setEnabled(True)
@@ -734,70 +735,81 @@ class WidgetGallery(QDialog):
         rc = subprocess.call("./appsAway_stopApp.sh")
 
     def setupEnvironment(self):
-        os.chdir(os.path.join(os.environ.get('HOME'), "teamcode","appsAway","demos", os.environ.get('APPSAWAY_APP_NAME')))
-        yml_files_default = ["main.yml", "composeGui.yml", "composeHead.yml"]
-        yml_files = []
+        # os.chdir(os.path.join(os.environ.get('HOME'), "teamcode","appsAway","demos", os.environ.get('APPSAWAY_APP_NAME')))
+        # yml_files_default = ["main.yml", "composeGui.yml", "composeHead.yml"]
+        # yml_files = []
 
-        for yml_file in yml_files_default:
-          if os.path.isfile(yml_file):
-            yml_files = yml_files + [yml_file]
+        # for yml_file in yml_files_default:
+        #   if os.path.isfile(yml_file):
+        #     yml_files = yml_files + [yml_file]
 
-        for yml_file in yml_files:
-          main_file = open(yml_file, "r")
-          main_list = main_file.read().split('\n')
+        # for yml_file in yml_files:
+        #   main_file = open(yml_file, "r")
+        #   main_list = main_file.read().split('\n')
 
-          custom_option_found = False
-          end_environ_set = False
-          if os.environ.get('APPSAWAY_SENSORS') != None:
-            list_sensors = os.environ.get('APPSAWAY_SENSORS').split(' ')
-            if yml_file == "composeHead.yml":
-              for i in range(len(main_list)):
-                if main_list[i].find("devices:") != -1:
-                  device_list=[]
-                  #main_list[i] = main_list[i] + "\n"
-                  for k in range(i+1,len(main_list),1):
-                    if main_list[k].find("command:") != -1:
-                      break
-                    tmp_device_shared = main_list[k].split('"')[1]    # device:device
-                    tmp_device = tmp_device_shared.split(":")[0]      # device
-                    device_list = device_list + [tmp_device]          # we create a list with all devices for this service
-                  for sensor in list_sensors:
-                    if sensor not in device_list and sensor != "":
-                      main_list[i] = main_list[i] + "\n      - \"" + sensor + ":" + sensor + "\"" #- "/dev/snd:/dev/snd"
+        #   custom_option_found = False
+        #   end_environ_set = False
+        #   if os.environ.get('APPSAWAY_SENSORS') != None:
+        #     list_sensors = os.environ.get('APPSAWAY_SENSORS').split(' ')
+        #     if yml_file == "composeHead.yml":
+        #       for i in range(len(main_list)):
+        #         if main_list[i].find("devices:") != -1:
+        #           device_list=[]
+        #           #main_list[i] = main_list[i] + "\n"
+        #           for k in range(i+1,len(main_list),1):
+        #             if main_list[k].find("command:") != -1:
+        #               break
+        #             tmp_device_shared = main_list[k].split('"')[1]    # device:device
+        #             tmp_device = tmp_device_shared.split(":")[0]      # device
+        #             device_list = device_list + [tmp_device]          # we create a list with all devices for this service
+        #           for sensor in list_sensors:
+        #             if sensor not in device_list and sensor != "":
+        #               main_list[i] = main_list[i] + "\n      - \"" + sensor + ":" + sensor + "\"" #- "/dev/snd:/dev/snd"
 
-          if os.environ.get('APPSAWAY_IMAGES') != '':
-            list_images = os.environ.get('APPSAWAY_IMAGES').split(' ')
-            list_versions = os.environ.get('APPSAWAY_VERSIONS').split(' ')
-            list_tags = os.environ.get('APPSAWAY_TAGS').split(' ')
+        #   if os.environ.get('APPSAWAY_IMAGES') != '':
+        #     list_images = os.environ.get('APPSAWAY_IMAGES').split(' ')
+        #     list_versions = os.environ.get('APPSAWAY_VERSIONS').split(' ')
+        #     list_tags = os.environ.get('APPSAWAY_TAGS').split(' ')
+        #     print("image list: ", list_images)            
 
-            for i in range(len(main_list)):
-              if main_list[i].find("x-yarp-") != -1:
-                if main_list[i+1].find("image") != -1:
-                  image_line = main_list[i+1]
-                  image_line = image_line.split(':')
-                  for f in range(len(list_images)):
-                    if image_line[1].strip() == list_images[f].strip(): # if the name is correct (the image name contains also the repository name - 'icubteamcode/superbuild')
-                      image_line[2] = list_versions[f] + "_" + list_tags[f] # we update the version
-                      break
-                  main_list[i+1] = image_line[0] + ':' + image_line[1] + ':' + image_line[2]
+        #     for i in range(len(main_list)):
+        #       if main_list[i].find("x-yarp-") != -1:
+        #         if main_list[i+1].find("image") != -1:
+        #           image_line = main_list[i+1]
+        #           image_line = image_line.split(':')
+                  
+        #           print("Flag:" ,os.environ.get('LOCAL_IMAGE_FLAG'))
+        #           if os.environ.get('LOCAL_IMAGE_FLAG').strip() == "true":
+        #             image_line[1] = "localhost:5000/" + os.environ.get('LOCAL_IMAGE_NAME').strip() # we update the version
+        #             main_list[i+1] = image_line[0] + ': ' + image_line[1] 
+        #             break
+  
+        #           for f in range(len(list_images)):
+        #             print("image line:", image_line[1].strip())
+        #             print("list_images[f]:", list_images[f].strip())
+                                          
+        #             if image_line[1].strip() == list_images[f].strip() : # if the name is correct (the image name contains also the repository name - 'icubteamcode/superbuild')
+        #               image_line[2] = list_versions[f] + "_" + list_tags[f] # we update the version
+        #               break
+        #           main_list[i+1] = image_line[0] + ':' + image_line[1] + ':' + image_line[2]
 
-          else:
-            for i in range(len(main_list)):
-              if main_list[i].find("x-yarp-base") != -1 or main_list[i].find("x-yarp-head") != -1 or main_list[i].find("x-yarp-gui") != -1:
-                if main_list[i+1].find("image") != -1:
-                  image_line = main_list[i+1]
-                  image_line = image_line.split(':')
-                  image_line[2] = os.environ.get('APPSAWAY_REPO_VERSION') + "_" + os.environ.get('APPSAWAY_REPO_TAG')
-                  main_list[i+1] = image_line[0] + ':' + image_line[1] + ':' + image_line[2]
+        #   else:
+        #     for i in range(len(main_list)):
+        #       if main_list[i].find("x-yarp-base") != -1 or main_list[i].find("x-yarp-head") != -1 or main_list[i].find("x-yarp-gui") != -1:
+        #         if main_list[i+1].find("image") != -1:
+        #           image_line = main_list[i+1]
+        #           image_line = image_line.split(':')
+        #           image_line[2] = os.environ.get('APPSAWAY_REPO_VERSION') + "_" + os.environ.get('APPSAWAY_REPO_TAG')
+        #           main_list[i+1] = image_line[0] + ':' + image_line[1] + ':' + image_line[2]
 
-            if main_list[i].find("services") != -1:
-                break
-          main_file.close()
-          main_file = open(yml_file, "w")
-          for i in range(len(main_list)-1):
-            main_file.write(main_list[i]+ '\n')
-          main_file.write(main_list[-1])
-          main_file.close()
+        #     if main_list[i].find("services") != -1:
+        #         break
+        #   main_file.close()
+        #   main_file = open(yml_file, "w")
+        #   for i in range(len(main_list)-1):
+        #     main_file.write(main_list[i]+ '\n')
+        #   main_file.write(main_list[-1])
+        #   main_file.close()
 
         # env file is located in iCubApps folder, so we need APPSAWAY_APP_PATH
         os.chdir(os.environ.get('APPSAWAY_APP_PATH'))

--- a/scripts/appsAway_copyFiles.sh
+++ b/scripts/appsAway_copyFiles.sh
@@ -127,7 +127,7 @@ init()
  os=`uname -s`
  if [ "$os" = "Darwin" ]
  then
-  #_ALL_LOCAL_IP_ADDRESSES=$(arp -a | awk -F'[()]' '{print $2}')
+  _ALL_LOCAL_IP_ADDRESSES=$(arp -a | awk -F'[()]' '{print $2}')
  else
   _ALL_LOCAL_IP_ADDRESSES=$(hostname --all-ip-address)
   _ALL_LOCAL_IP_ADDRESSES+=$(hostname --all-fqdns)
@@ -249,13 +249,13 @@ overwrite_yaml_files()
   yml_files=()
   
   for (( i=0; i<$yml_files_default_len; i++ ))
-  do    
-      if [ -f "${yml_files_default[$i]}" ]
+  do
+      echo "files are: ${APPSAWAY_APP_PATH}/${yml_files_default[$i]}"    
+      if [ -f "${APPSAWAY_APP_PATH}/${yml_files_default[$i]}" ]
       then
-          yml_files+=(${yml_files_default[$i]})
+          yml_files+=("${APPSAWAY_APP_PATH}/${yml_files_default[$i]}")
       fi
   done
-  echo "files: ${yml_files[@]}"
   for (( i=0; i<${#yml_files[@]}; i++ ))
   do
       if [[ $APPSAWAY_IMAGES != '' ]] 
@@ -266,10 +266,12 @@ overwrite_yaml_files()
       
           if [[ $LOCAL_IMAGE_FLAG == true ]]
           then
+              echo "overwriting localhost:5000/${LOCAL_IMAGE_NAME} in ${yml_files[$i]}" 
               sed -i 's,image: .*$,image: '"localhost:5000/${LOCAL_IMAGE_NAME}"',g' ${yml_files[$i]}
           else
               for (( j=0; j<${#list_images[@]}; j++ ))
               do
+                  echo "overwriting ${list_images[$j]} in ${yml_files[$i]}" 
                   sed -i 's,image: '"${list_images[$j]}"'.*$,image: '"${list_images[$j]}"':'"${list_versions[$j]}"'_'"${list_tags[$j]}"',g' ${yml_files[$i]}
               done
           fi    
@@ -323,7 +325,7 @@ overwrite_yaml_files()
                     echo "sensors to add: ${sensors_to_add[@]}"
                     for sens_to_add in "${sensors_to_add[@]}"
                     do
-                      sed -i 's,'"${line}"'.*$,'"    - \"${sens_to_add}"':'"${sens_to_add}\"\n  ${line}"',g' ${yml_files[$i]}      
+                      sed -i 's,'"${line}"'.*$,'"    - \"${sens_to_add}"':'"${sens_to_add}\"\n  ${line}"',g' ${yml_files[$i]}    
                     done   
                     append_sensors=false
                     sensors_to_add=""
@@ -337,86 +339,14 @@ overwrite_yaml_files()
             done < ${yml_files[$i]}
           fi
       fi
-  done
-
-    # for yml_file in yml_files_default:
-    #   if os.path.isfile(yml_file):
-    #     yml_files = yml_files + [yml_file]
-
-    # for yml_file in yml_files:
-    #   main_file = open(yml_file, "r")
-    #   main_list = main_file.read().split('\n')
-
-    #   custom_option_found = False
-    #   end_environ_set = False
-    #   if os.environ.get('APPSAWAY_SENSORS') != None:
-    #     list_sensors = os.environ.get('APPSAWAY_SENSORS').split(' ')
-    #     if yml_file == "composeHead.yml":
-    #       for i in range(len(main_list)):
-    #         if main_list[i].find("devices:") != -1:
-    #           device_list=[]
-    #           #main_list[i] = main_list[i] + "\n"
-    #           for k in range(i+1,len(main_list),1):
-    #             if main_list[k].find("command:") != -1:
-    #               break
-    #             tmp_device_shared = main_list[k].split('"')[1]    # device:device
-    #             tmp_device = tmp_device_shared.split(":")[0]      # device
-    #             device_list = device_list + [tmp_device]          # we create a list with all devices for this service
-    #           for sensor in list_sensors:
-    #             if sensor not in device_list and sensor != "":
-    #               main_list[i] = main_list[i] + "\n      - \"" + sensor + ":" + sensor + "\"" #- "/dev/snd:/dev/snd"
-
-    #   if os.environ.get('APPSAWAY_IMAGES') != '':
-    #     list_images = os.environ.get('APPSAWAY_IMAGES').split(' ')
-    #     list_versions = os.environ.get('APPSAWAY_VERSIONS').split(' ')
-    #     list_tags = os.environ.get('APPSAWAY_TAGS').split(' ')
-    #     print("image list: ", list_images)            
-
-    #     for i in range(len(main_list)):
-    #       if main_list[i].find("x-yarp-") != -1:
-    #         if main_list[i+1].find("image") != -1:
-    #           image_line = main_list[i+1]
-    #           image_line = image_line.split(':')
-                
-    #           print("Flag:" ,os.environ.get('LOCAL_IMAGE_FLAG'))
-    #           if os.environ.get('LOCAL_IMAGE_FLAG').strip() == "true":
-    #             image_line[1] = "localhost:5000/" + os.environ.get('LOCAL_IMAGE_NAME').strip() # we update the version
-    #             main_list[i+1] = image_line[0] + ': ' + image_line[1] 
-    #             break
-
-    #           for f in range(len(list_images)):
-    #             print("image line:", image_line[1].strip())
-    #             print("list_images[f]:", list_images[f].strip())
-                                        
-    #             if image_line[1].strip() == list_images[f].strip() : # if the name is correct (the image name contains also the repository name - 'icubteamcode/superbuild')
-    #               image_line[2] = list_versions[f] + "_" + list_tags[f] # we update the version
-    #               break
-    #           main_list[i+1] = image_line[0] + ':' + image_line[1] + ':' + image_line[2]
-
-    #   else:
-    #     for i in range(len(main_list)):
-    #       if main_list[i].find("x-yarp-base") != -1 or main_list[i].find("x-yarp-head") != -1 or main_list[i].find("x-yarp-gui") != -1:
-    #         if main_list[i+1].find("image") != -1:
-    #           image_line = main_list[i+1]
-    #           image_line = image_line.split(':')
-    #           image_line[2] = os.environ.get('APPSAWAY_REPO_VERSION') + "_" + os.environ.get('APPSAWAY_REPO_TAG')
-    #           main_list[i+1] = image_line[0] + ':' + image_line[1] + ':' + image_line[2]
-
-    #     if main_list[i].find("services") != -1:
-    #         break
-    #   main_file.close()
-    #   main_file = open(yml_file, "w")
-    #   for i in range(len(main_list)-1):
-    #     main_file.write(main_list[i]+ '\n')
-    #   main_file.write(main_list[-1])
-    #   main_file.close()
-  
+  done  
 }
 
 copy_yaml_files()
 {
   log "creating path ${APPSAWAY_APP_PATH} on master node (this)"
   mkdir -p ${APPSAWAY_APP_PATH}
+  echo "yml files: ${APPSAWAY_DEPLOY_YAML_FILE_LIST}"
   for file in ${APPSAWAY_DEPLOY_YAML_FILE_LIST}
   do
     if [ -f "../demos/$APPSAWAY_APP_NAME/$file" ]; then
@@ -425,7 +355,7 @@ copy_yaml_files()
     fi
   done
   log "modifying yaml file $file on master node (this)"
-  
+  echo "gui files: ${APPSAWAY_GUI_YAML_FILE_LIST}"
   for file in ${APPSAWAY_GUI_YAML_FILE_LIST}
   do
     if [ -f "../demos/$APPSAWAY_APP_NAME/$file" ]; then
@@ -433,6 +363,17 @@ copy_yaml_files()
       cp ../demos/${APPSAWAY_APP_NAME}/${file} ${APPSAWAY_APP_PATH}/
     fi
   done
+  log "modifying yaml file $file on master node (this)"
+  echo "head files: ${APPSAWAY_HEAD_YAML_FILE_LIST}"
+  for file in ${APPSAWAY_HEAD_YAML_FILE_LIST}
+  do
+    if [ -f "../demos/$APPSAWAY_APP_NAME/$file" ]; then
+      log "copying yaml file $file to master node (this)"
+      cp ../demos/${APPSAWAY_APP_NAME}/${file} ${APPSAWAY_APP_PATH}/
+    fi
+  done
+  log "modifying yaml files"
+  overwrite_yaml_files
   APPSAWAY_DATA_FOLDERS=$( ls ../demos/$APPSAWAY_APP_NAME/ )
   echo "the folders are $APPSAWAY_DATA_FOLDERS"
   for folder in ${APPSAWAY_DATA_FOLDERS}
@@ -444,7 +385,7 @@ copy_yaml_files()
     if [ -d "../demos/$APPSAWAY_APP_NAME/$folder" ]
     then
       log "copying data folder $folder to master node (this)"
-      cp -R ../demos/${APPSAWAY_APP_NAME}/${folder} ${APPSAWAY_APP_PATH}/
+      cp -R ${APPSAWAY_APP_PATH}/${folder} ${APPSAWAY_APP_PATH}/
     fi
   done
   if [ "$APPSAWAY_ICUBHEADNODE_ADDR" != "" ]; then
@@ -454,7 +395,7 @@ copy_yaml_files()
     do
       if [ -f "../demos/$APPSAWAY_APP_NAME/$file" ]; then
         log "copying yaml file $file to node with IP $APPSAWAY_ICUBHEADNODE_ADDR"
-        ${_SCP_BIN} ${_SCP_PARAMS} ../demos/${APPSAWAY_APP_NAME}/${file} ${APPSAWAY_ICUBHEADNODE_USERNAME}@${APPSAWAY_ICUBHEADNODE_ADDR}:${APPSAWAY_APP_PATH}/
+        ${_SCP_BIN} ${_SCP_PARAMS} ${APPSAWAY_APP_PATH}/${file} ${APPSAWAY_ICUBHEADNODE_USERNAME}@${APPSAWAY_ICUBHEADNODE_ADDR}:${APPSAWAY_APP_PATH}/
       fi
     done
   fi
@@ -466,7 +407,7 @@ copy_yaml_files()
     do
       if [ -f "../demos/$APPSAWAY_APP_NAME/$file" ]; then
         log "copying yaml file $file to node with IP $APPSAWAY_GUINODE_ADDR"
-        ${_SCP_BIN} ${_SCP_PARAMS} ../demos/${APPSAWAY_APP_NAME}/${file} ${APPSAWAY_GUINODE_USERNAME}@${APPSAWAY_GUINODE_ADDR}:${APPSAWAY_APP_PATH}/
+        ${_SCP_BIN} ${_SCP_PARAMS} ${APPSAWAY_APP_PATH}/${file} ${APPSAWAY_GUINODE_USERNAME}@${APPSAWAY_GUINODE_ADDR}:${APPSAWAY_APP_PATH}/
       fi
     done
   elif [ "$APPSAWAY_GUINODE_ADDR" == "" ] && [ "$APPSAWAY_CONSOLENODE_ADDR" != "" ]; then
@@ -476,7 +417,7 @@ copy_yaml_files()
     do
       if [ -f "../demos/$APPSAWAY_APP_NAME/$file" ]; then
         log "copying yaml file $file to node with IP $APPSAWAY_CONSOLENODE_ADDR"
-        ${_SCP_BIN} ${_SCP_PARAMS} ../demos/${APPSAWAY_APP_NAME}/${file} ${APPSAWAY_CONSOLENODE_USERNAME}@${APPSAWAY_CONSOLENODE_ADDR}:${APPSAWAY_APP_PATH}/
+        ${_SCP_BIN} ${_SCP_PARAMS} ${APPSAWAY_APP_PATH}/${file} ${APPSAWAY_CONSOLENODE_USERNAME}@${APPSAWAY_CONSOLENODE_ADDR}:${APPSAWAY_APP_PATH}/
       fi
     done
   fi

--- a/scripts/appsAway_startApp.sh
+++ b/scripts/appsAway_startApp.sh
@@ -188,9 +188,32 @@ run_deploy()
   log "executing docker stack deploy"
   cd $APPSAWAY_APP_PATH
   export $(cat .env)
+
+  if [[ ${LOCAL_IMAGE_FLAG} == true ]]
+  then    
+    REGISTRY_UP_FLAG=true
+    registry_up=$(${_DOCKER_BIN} service ls | grep "*:5000->5000/tcp" | tr -d ' ') 
+    if [ "$registry_up" == "" ]
+    then     
+      REGISTRY_UP_FLAG=false
+      echo "Creating the local registry"
+      ${_DOCKER_BIN} service create --name registry --publish published=5000,target=5000 registry:2 
+    fi
+    echo "Registry_up_flag: $REGISTRY_UP_FLAG"
+    echo "export REGISTRY_UP_FLAG=$REGISTRY_UP_FLAG" >> ${HOME}/teamcode/appsAway/scripts/${_APPSAWAY_ENVFILE}
+    
+    ${_DOCKER_BIN} tag ${LOCAL_IMAGE_NAME} localhost:5000/${LOCAL_IMAGE_NAME}
+    ${_DOCKER_BIN} push localhost:5000/${LOCAL_IMAGE_NAME}
+    # echo "export APPSAWAY_IMAGES=\"localhost:5000/${LOCAL_IMAGE_NAME}\"" >> ${HOME}/teamcode/appsAway/scripts/appsAway_setEnvironment.local.sh
+    # source ${HOME}/teamcode/appsAway/scripts/appsAway_setEnvironment.local.sh
+    # for i in "${!APPSAWAY_IMAGES[@]}"; 
+    # do
+    #   ${_DOCKER_BIN} push ${APPSAWAY_IMAGES[$i]}:${APPSAWAY_VERSIONS[$i]}
+    # done 
+  fi  
   for _file2deploy in ${APPSAWAY_DEPLOY_YAML_FILE_LIST}
-  do
-    log "downloading the image: ${_DOCKER_COMPOSE_BIN} -f ${_file2deploy} pull "
+  do       
+    log "downloading the image: ${_DOCKER_COMPOSE_BIN} -f ${_file2deploy} up" # pull "
     ${_DOCKER_COMPOSE_BIN} -f ${_file2deploy} pull
     log "pushing image into service registry for distribution in swarm"
     ${_DOCKER_COMPOSE_BIN} -f ${_file2deploy} push

--- a/scripts/appsAway_stopApp.sh
+++ b/scripts/appsAway_stopApp.sh
@@ -222,10 +222,15 @@ stop_deploy()
   log "executing docker stack deploy"
   export $(cat .env)
   #cd $APPSAWAY_APP_PATH
-  for _file2deploy in ${APPSAWAY_DEPLOY_YAML_FILE_LIST}
-  do
+  #for _file2deploy in ${APPSAWAY_DEPLOY_YAML_FILE_LIST}
+  #do
     ${_DOCKER_BIN} ${_DOCKER_PARAMS} stack rm ${APPSAWAY_STACK_NAME}
-  done
+  #done
+  echo "registry flag: ${REGISTRY_UP_FLAG}"
+  if [[ ${LOCAL_IMAGE_FLAG} == true && ${REGISTRY_UP_FLAG} == false ]]
+  then
+    ${_DOCKER_BIN} service rm registry
+  fi
 }
 
 


### PR DESCRIPTION
This PR handles local images inside the pipeline. 
As a _proof of concept_ we used `yarpBasicDeploy`, adding the following options to the gui:
- `LOCAL_IMAGE_FLAG`: specifies if a local image will be used 
- `LOCAL_IMAGE_NAME`: specifies the name of the local image
![Screenshot from 2021-07-01 08-24-57](https://user-images.githubusercontent.com/9716288/124075915-d836ca00-da45-11eb-9901-507cefbf82c9.png)

We introduced the following changes to the pipeline:

- **`appsAway_startApp.sh`**:
when `LOCAL_IMAGE_FLAG` is true, if there is no registry with the port 5000 running, we create it, rename the image appending `localhost:5000/` beforehand, and then push it to the _local registry_. Otherwise, we skip the creation of the registry:

- **`main.py`** of the gui and **`appsAway_copyFiles.sh`:** 
the `appsAway_copyFile.sh` is now in charge of handling the overwriting of the images onto the ymls, and not the gui anymore. 
  The pipeline **before the changes** included the following steps:
  1. overwrite the yml files with `APPSAWAY_IMAGES` and `APPSAWAY_SENSORS` **inside `${HOME}/teamcode/appsAway`**
  2. copy them into `iCubApps` onto the master node
  3. copy them onto the nodes inside the cluster
  
  This was generating an issue when starting the application **first** with a local image and **then**  with the original image (i.e. `icubteamcode/superbuild`). This was because the gui **during the first step** changed the files inside  `${HOME}/teamcode/appsAway` to include the local image and **during the second step** the match with `icubteamcode/superbuild` was not found anymore.
  
  To solve this issue now we do:
  1. copy yml files into `iCubApps` onto the master node
  2. overwrite the yml files **inside `iCubApps`** with `APPSAWAY_IMAGES` and `APPSAWAY_SENSORS` 
  3. copy the modified files onto the nodes inside the cluster
  
  In this way, we always keep the original file version inside `${HOME}/teamcode/appsAway`.
  
- **`appsAway_stopApp.sh`**:
we remove the registry, if no registry was found onto the host machine

I tested the pipeline onto my machine and it works with both local images and not.