### PR TITLE
Updating local images handling within swarm

### DIFF
--- a/scripts/ansible_setup/Makefile
+++ b/scripts/ansible_setup/Makefile
@@ -9,3 +9,7 @@ cluster:
 .PHONY: destroy
 destroy:
 	ansible-playbook -K destroy.yml
+	
+.PHONY: prepare_local_registry
+prepare_local_registry:
+	ansible-playbook -i hosts.ini -e @passwords.enc --vault-password-file vault_password_file.txt prepare_local_registry.yml 

--- a/scripts/ansible_setup/prepare_local_registry.yml
+++ b/scripts/ansible_setup/prepare_local_registry.yml
@@ -1,0 +1,22 @@
+- name: Prepare local registry
+  hosts: nodes
+  become: yes
+  tasks:      
+    - name: Adding local registry
+      shell: echo "{ \"insecure-registries\":[\""{{ ansible_console_host }}":5000\"] }" > /etc/docker/daemon.json
+
+    - name: Stop docker
+      shell: sudo systemctl stop docker
+      args:
+        warn: no
+      when: ansible_distribution != 'MacOSX'
+
+    - name: Start docker
+      shell: sudo systemctl start docker
+      retries: 3
+      delay: 30
+      register: result
+      until: result.rc == 0
+      args:
+        warn: no
+      when: ansible_distribution != 'MacOSX'

--- a/scripts/ansible_setup/setup_hosts_ini.sh
+++ b/scripts/ansible_setup/setup_hosts_ini.sh
@@ -29,6 +29,7 @@ ${nodes_name_array[$i]}Laptop ansible_host=${nodes_addr_array[$i]}
 [${nodes_name_array[$i]}:vars]
 ansible_ssh_user=\"${nodes_usr_array[$i]}\"
 ansible_become_pass={{ ${nodes_name_array[$i]}_pass }}
+ansible_console_host=${APPSAWAY_CONSOLENODE_ADDR}
 " >> ./hosts.ini
 done
 

--- a/scripts/appsAway_copyFiles.sh
+++ b/scripts/appsAway_copyFiles.sh
@@ -266,8 +266,8 @@ overwrite_yaml_files()
       
           if [[ $LOCAL_IMAGE_FLAG == true ]]
           then
-              echo "overwriting localhost:5000/${LOCAL_IMAGE_NAME} in ${yml_files[$i]}" 
-              sed -i 's,image: .*$,image: '"localhost:5000/${LOCAL_IMAGE_NAME}"',g' ${yml_files[$i]}
+              echo "overwriting ${APPSAWAY_CONSOLENODE_ADDR}:5000/${LOCAL_IMAGE_NAME} in ${yml_files[$i]}" 
+              sed -i 's,image: .*$,image: '"${APPSAWAY_CONSOLENODE_ADDR}:5000/${LOCAL_IMAGE_NAME}"',g' ${yml_files[$i]}
           else
               for (( j=0; j<${#list_images[@]}; j++ ))
               do

--- a/scripts/appsAway_startApp.sh
+++ b/scripts/appsAway_startApp.sh
@@ -202,8 +202,8 @@ run_deploy()
     echo "Registry_up_flag: $REGISTRY_UP_FLAG"
     echo "export REGISTRY_UP_FLAG=$REGISTRY_UP_FLAG" >> ${HOME}/teamcode/appsAway/scripts/${_APPSAWAY_ENVFILE}
     
-    ${_DOCKER_BIN} tag ${LOCAL_IMAGE_NAME} localhost:5000/${LOCAL_IMAGE_NAME}
-    ${_DOCKER_BIN} push localhost:5000/${LOCAL_IMAGE_NAME}
+    ${_DOCKER_BIN} tag ${LOCAL_IMAGE_NAME} ${APPSAWAY_CONSOLENODE_ADDR}:5000/${LOCAL_IMAGE_NAME}
+    ${_DOCKER_BIN} push ${APPSAWAY_CONSOLENODE_ADDR}:5000/${LOCAL_IMAGE_NAME}
     # echo "export APPSAWAY_IMAGES=\"localhost:5000/${LOCAL_IMAGE_NAME}\"" >> ${HOME}/teamcode/appsAway/scripts/appsAway_setEnvironment.local.sh
     # source ${HOME}/teamcode/appsAway/scripts/appsAway_setEnvironment.local.sh
     # for i in "${!APPSAWAY_IMAGES[@]}"; 


### PR DESCRIPTION
This PR introduces changes to make the local registry visible to the nodes inside the swarm.

As per [this](https://github.com/icub-tech-iit/code/issues/656#issuecomment-868350710) comment, by default the registry is insecure and Docker rejects it. To allow access, we need to modify the `/etc/docker/daemon.json` file inside each worker node with the following line:

```
>/etc/docker/daemon.json
{
    "insecure-registries" : ["<REGISTRY_IP>:5000"]
}
```

and consequently, restart docker.
To handle this, we created a new Ansible playbook, called `prepare_local_registry.yml`, which we run from the cluster setup.
This is still draft as we need to integrate also changes inside the cluster setup.
