### PR TITLE
Handle local images through the website

### DIFF
--- a/demos/yarpBasicDeploy/gui/gui_conf.ini
+++ b/demos/yarpBasicDeploy/gui/gui_conf.ini
@@ -3,11 +3,3 @@ title "YARP Basic Demo"
 
 [top options] 
 ImageName "images/yarpview.png"
- 
-[right options]
-toggleButton "" "Local image" LOCAL_IMAGE_FLAG true/false on unticked
-textEditBox "Specify Local image" "" LOCAL_IMAGE_NAME None on None
-
-[Button hierarchy]
-Dependency - LOCAL_IMAGE_NAME - ( {LOCAL_IMAGE_FLAG selected enable} )
-

--- a/demos/yarpBasicDeploy/test-script.sh
+++ b/demos/yarpBasicDeploy/test-script.sh
@@ -108,8 +108,6 @@ echo "tags: $APPSAWAY_TAGS"
 echo "about to setup the cluster..." 
 ./appsAway_setupCluster.sh
 
-echo "
-LOCAL_IMAGE_FLAG=false" >> $HOME/iCubApps/$APPSAWAY_APP_NAME/.env 
 
 ./appsAway_setupSwarm.sh
 setupEnvironment

--- a/scripts/appsAway_copyFiles.sh
+++ b/scripts/appsAway_copyFiles.sh
@@ -272,21 +272,21 @@ overwrite_yaml_files()
   do
       if [[ $APPSAWAY_IMAGES != '' ]] 
       then
-          list_images=($APPSAWAY_IMAGES)
-          list_versions=($APPSAWAY_VERSIONS)
-          list_tags=($APPSAWAY_TAGS)
-      
-          if [[ $LOCAL_IMAGE_FLAG == true ]]
-          then
-              echo "overwriting ${APPSAWAY_CONSOLENODE_ADDR}:5000/${LOCAL_IMAGE_NAME} in ${yml_files[$i]}" 
-              sed -i 's,image: .*$,image: '"${APPSAWAY_CONSOLENODE_ADDR}:5000/${LOCAL_IMAGE_NAME}"',g' ${yml_files[$i]}
-          else
-              for (( j=0; j<${#list_images[@]}; j++ ))
-              do
-                  echo "overwriting ${list_images[$j]} in ${yml_files[$i]}" 
-                  sed -i 's,image: '"${list_images[$j]}"'.*$,image: '"${list_images[$j]}"':'"${list_versions[$j]}"'_'"${list_tags[$j]}"',g' ${yml_files[$i]}
-              done
-          fi    
+        list_images=($APPSAWAY_IMAGES)
+        list_yml_images=($APPSAWAY_YML_IMAGES)
+        list_versions=($APPSAWAY_VERSIONS)
+        list_tags=($APPSAWAY_TAGS)
+  
+        for (( j=0; j<${#list_images[@]}; j++ ))
+        do
+            echo "overwriting ${list_yml_images[$j]} with ${list_images[$j]} in ${yml_files[$i]}" 
+            if [[ ${list_versions[$j]} == "n/a" ]]
+            then
+              sed -i 's,image: '"${list_yml_images[$j]}"'.*$,image: '"${list_images[$j]}"':'"${list_tags[$j]}"',g' ${yml_files[$i]}
+            else
+              sed -i 's,image: '"${list_yml_images[$j]}"'.*$,image: '"${list_images[$j]}"':'"${list_versions[$j]}"'_'"${list_tags[$j]}"',g' ${yml_files[$i]}
+            fi 
+        done         
       fi
 
       if [[ $APPSAWAY_SENSORS != '' ]] 

--- a/scripts/appsAway_setupCluster.sh
+++ b/scripts/appsAway_setupCluster.sh
@@ -358,6 +358,7 @@ find_docker_images()
     else
       current_image=${APPSAWAY_IMAGES_LIST[$index]}:${APPSAWAY_TAGS_LIST[$index]}
     fi
+    echo "Pulling image $current_image, this might take a few minutes..."
     result=$(${_DOCKER_BIN} pull --quiet $current_image &> /dev/null || true)
     if [[ $result != "" ]]
     then

--- a/scripts/appsAway_setupCluster.sh
+++ b/scripts/appsAway_setupCluster.sh
@@ -346,9 +346,7 @@ find_docker_images()
       ${_DOCKER_BIN} service update ${return_list[0]}
     fi
   fi
-
-
-
+  
   echo "Registry_up_flag: $REGISTRY_UP_FLAG"
   echo "export REGISTRY_UP_FLAG=$REGISTRY_UP_FLAG" >> ${HOME}/teamcode/appsAway/scripts/${_APPSAWAY_ENV_FILE}
 
@@ -364,18 +362,16 @@ find_docker_images()
     if [[ $result != "" ]]
     then
       ${_DOCKER_BIN} tag $current_image ${APPSAWAY_CONSOLENODE_ADDR}:5000/$current_image
-      log "Before the push"
+      log "Pushing $current_image into the local registry"
       ${_DOCKER_BIN} push ${APPSAWAY_CONSOLENODE_ADDR}:5000/$current_image
-      log "After the push"
       APPSAWAY_REGISTRY_IMAGES="$APPSAWAY_REGISTRY_IMAGES ${APPSAWAY_CONSOLENODE_ADDR}:5000/${APPSAWAY_IMAGES_LIST[$index]}"
     else
       IMAGE_FOUND_LOCALLY=$(${_DOCKER_BIN} images --format "{{.Repository}}:{{.Tag}}" | grep $current_image) 
       if [[ $IMAGE_FOUND_LOCALLY != "" ]]  
       then
         ${_DOCKER_BIN} tag $current_image ${APPSAWAY_CONSOLENODE_ADDR}:5000/$current_image
-        log "Before the push"
+        log "Pushing $current_image into the local registry"
         ${_DOCKER_BIN} push ${APPSAWAY_CONSOLENODE_ADDR}:5000/$current_image
-        log "After the push"
         APPSAWAY_REGISTRY_IMAGES="$APPSAWAY_REGISTRY_IMAGES ${APPSAWAY_CONSOLENODE_ADDR}:5000/${APPSAWAY_IMAGES_LIST[$index]}" 
       else
         exit_err "Image $current_image was not found on DockerHub nor locally. Please be sure that the name is correct."

--- a/scripts/appsAway_setupCluster.sh
+++ b/scripts/appsAway_setupCluster.sh
@@ -336,8 +336,19 @@ find_docker_images()
   then     
     REGISTRY_UP_FLAG=false
     echo "Creating the local registry"
-    ${_DOCKER_BIN} service create --name registry --publish published=5000,target=5000 registry:2 
+    ${_DOCKER_BIN} service create --name registry \
+    --publish published=5000,target=5000 --replicas 1 registry:2 
+  else
+    return=$(${_DOCKER_BIN} service ls | grep "*:5000->5000/tcp")
+    if [[ $return != "" ]]
+    then
+      return_list=($return)
+      ${_DOCKER_BIN} service update ${return_list[0]}
+    fi
   fi
+
+
+
   echo "Registry_up_flag: $REGISTRY_UP_FLAG"
   echo "export REGISTRY_UP_FLAG=$REGISTRY_UP_FLAG" >> ${HOME}/teamcode/appsAway/scripts/${_APPSAWAY_ENV_FILE}
 

--- a/scripts/appsAway_setupCluster.sh
+++ b/scripts/appsAway_setupCluster.sh
@@ -325,10 +325,59 @@ copy_yarp_files()
   done
 }
 
+find_docker_images()
+{
+  APPSAWAY_IMAGES_LIST=($APPSAWAY_IMAGES)
+  APPSAWAY_VERSIONS_LIST=($APPSAWAY_VERSIONS)
+  APPSAWAY_TAGS_LIST=($APPSAWAY_TAGS)
+  REGISTRY_UP_FLAG=true
+  registry_up=$(${_DOCKER_BIN} service ls | grep "*:5000->5000/tcp" | tr -d ' ') 
+  if [ "$registry_up" == "" ]
+  then     
+    REGISTRY_UP_FLAG=false
+    echo "Creating the local registry"
+    ${_DOCKER_BIN} service create --name registry --publish published=5000,target=5000 registry:2 
+  fi
+  echo "Registry_up_flag: $REGISTRY_UP_FLAG"
+  echo "export REGISTRY_UP_FLAG=$REGISTRY_UP_FLAG" >> ${HOME}/teamcode/appsAway/scripts/${_APPSAWAY_ENV_FILE}
 
+  for index in "${!APPSAWAY_IMAGES_LIST[@]}"
+  do
+    if [[ ${APPSAWAY_VERSIONS_LIST[$index]} != "n/a" ]]
+    then
+      current_image=${APPSAWAY_IMAGES_LIST[$index]}:${APPSAWAY_VERSIONS_LIST[$index]}_${APPSAWAY_TAGS_LIST[$index]}
+    else
+      current_image=${APPSAWAY_IMAGES_LIST[$index]}:${APPSAWAY_TAGS_LIST[$index]}
+    fi
+    result=$(${_DOCKER_BIN} pull --quiet $current_image &> /dev/null || true)
+    if [[ $result != "" ]]
+    then
+      ${_DOCKER_BIN} tag $current_image ${APPSAWAY_CONSOLENODE_ADDR}:5000/$current_image
+      log "Before the push"
+      ${_DOCKER_BIN} push ${APPSAWAY_CONSOLENODE_ADDR}:5000/$current_image
+      log "After the push"
+      APPSAWAY_REGISTRY_IMAGES="$APPSAWAY_REGISTRY_IMAGES ${APPSAWAY_CONSOLENODE_ADDR}:5000/${APPSAWAY_IMAGES_LIST[$index]}"
+    else
+      IMAGE_FOUND_LOCALLY=$(${_DOCKER_BIN} images --format "{{.Repository}}:{{.Tag}}" | grep $current_image) 
+      if [[ $IMAGE_FOUND_LOCALLY != "" ]]  
+      then
+        ${_DOCKER_BIN} tag $current_image ${APPSAWAY_CONSOLENODE_ADDR}:5000/$current_image
+        log "Before the push"
+        ${_DOCKER_BIN} push ${APPSAWAY_CONSOLENODE_ADDR}:5000/$current_image
+        log "After the push"
+        APPSAWAY_REGISTRY_IMAGES="$APPSAWAY_REGISTRY_IMAGES ${APPSAWAY_CONSOLENODE_ADDR}:5000/${APPSAWAY_IMAGES_LIST[$index]}" 
+      else
+        exit_err "Image $current_image was not found on DockerHub nor locally. Please be sure that the name is correct."
+      fi
+    fi
+  done
+  echo "export APPSAWAY_IMAGES=\"$APPSAWAY_REGISTRY_IMAGES\"" >> ${HOME}/teamcode/appsAway/scripts/appsAway_setEnvironment.local.sh
+  source ${HOME}/teamcode/appsAway/scripts/appsAway_setEnvironment.local.sh
+}
 
 main()
-{
+{ 
+  find_docker_images
   copy_yaml_files
   create_yarp_config_files
   create_env_file

--- a/scripts/appsAway_startApp.sh
+++ b/scripts/appsAway_startApp.sh
@@ -205,29 +205,7 @@ run_deploy()
   log "executing docker stack deploy"
   cd $APPSAWAY_APP_PATH
   export $(cat .env)
-
-  if [[ ${LOCAL_IMAGE_FLAG} == true ]]
-  then    
-    REGISTRY_UP_FLAG=true
-    registry_up=$(${_DOCKER_BIN} service ls | grep "*:5000->5000/tcp" | tr -d ' ') 
-    if [ "$registry_up" == "" ]
-    then     
-      REGISTRY_UP_FLAG=false
-      echo "Creating the local registry"
-      ${_DOCKER_BIN} service create --name registry --publish published=5000,target=5000 registry:2 
-    fi
-    echo "Registry_up_flag: $REGISTRY_UP_FLAG"
-    echo "export REGISTRY_UP_FLAG=$REGISTRY_UP_FLAG" >> ${HOME}/teamcode/appsAway/scripts/${_APPSAWAY_ENVFILE}
-    
-    ${_DOCKER_BIN} tag ${LOCAL_IMAGE_NAME} ${APPSAWAY_CONSOLENODE_ADDR}:5000/${LOCAL_IMAGE_NAME}
-    ${_DOCKER_BIN} push ${APPSAWAY_CONSOLENODE_ADDR}:5000/${LOCAL_IMAGE_NAME}
-    # echo "export APPSAWAY_IMAGES=\"localhost:5000/${LOCAL_IMAGE_NAME}\"" >> ${HOME}/teamcode/appsAway/scripts/appsAway_setEnvironment.local.sh
-    # source ${HOME}/teamcode/appsAway/scripts/appsAway_setEnvironment.local.sh
-    # for i in "${!APPSAWAY_IMAGES[@]}"; 
-    # do
-    #   ${_DOCKER_BIN} push ${APPSAWAY_IMAGES[$i]}:${APPSAWAY_VERSIONS[$i]}
-    # done 
-  fi  
+  
   for _file2deploy in ${APPSAWAY_DEPLOY_YAML_FILE_LIST}
   do       
     log "downloading the image: ${_DOCKER_COMPOSE_BIN_CONSOLE} -f ${_file2deploy} up" # pull "

--- a/scripts/appsAway_stopApp.sh
+++ b/scripts/appsAway_stopApp.sh
@@ -246,7 +246,7 @@ stop_deploy()
     ${_DOCKER_BIN} ${_DOCKER_PARAMS} stack rm ${APPSAWAY_STACK_NAME}
   #done
   echo "registry flag: ${REGISTRY_UP_FLAG}"
-  if [[ ${LOCAL_IMAGE_FLAG} == true && ${REGISTRY_UP_FLAG} == false ]]
+  if [[ ${REGISTRY_UP_FLAG} == false ]]
   then
     ${_DOCKER_BIN} service rm registry
   fi


### PR DESCRIPTION
With this PR we want to add the possibility to handle multiple local images directly through the cluster setup dialog on the website.

Below you can find the changes that we implemented in the scripts:
- **`appsAway_setupCluster.sh`** : we created the function `find_docker_images()` which:
  - checks for the local registry: if it doesn't find it, it creates it; otherwise, it relaunches the registry service 
  - for each image in `APPSAWAY_IMAGES`, tries to pull it from DockerHub:
    - if successful, we append `${APPSAWAY_CONSOLENODE_ADDR}:5000/` to the image name, we push it into the local registry and we update the `APPSAWAY_IMAGES` variable
    - if it's not successful, we check if the image is present locally 
        - if yes, again we rename the image and we push it into the local registry, updating the variable `APPSAWAY_IMAGES` 
        - if not, it means the user has inserted a wrong name, so we notify the user with a message and we exit from the script with an error.
  - exports the variable `APPSAWAY_IMAGES` in `appsAway_setEnvironment.local.sh`

- **`appsAway_startApp.sh`**: we removed the creation of the local registry and the pushing of the images which is now done in `appsAway_setupCluster.sh`

- **`appsAway_copyFiles.sh`**: we restructured the replacement of the image names in the `.yml` files to account for the local images and their tags (local images don't have versions)
