### PR TITLE
Implemented changes to handle the pipeline to test newly added application

### DIFF
--- a/.github/workflows/triggering_new_app_test.yml
+++ b/.github/workflows/triggering_new_app_test.yml
@@ -1,0 +1,29 @@
+name: Triggering new app test
+
+on:
+  pull_request:
+    types: [opened]
+    branches:
+        - master 
+jobs:
+    triggering_code:
+      runs-on: ubuntu-latest
+      if: contains(github.event.pull_request.head.ref, 'add_app')
+      steps:  
+      - name: Get Token
+        id: get_workflow_token
+        uses: tibdex/github-app-token@v1
+        with:
+          private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+          app_id: ${{ secrets.APPLICATION_ID }}
+          repository: icub-tech-iit/code
+            
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v1
+        env:
+          GITHUB_APPS_TOKEN: ${{ steps.get_workflow_token.outputs.token }}
+        with:
+          token: ${{ env.GITHUB_APPS_TOKEN }}   
+          repository: icub-tech-iit/code
+          event-type: add_app_testing_from_appsaway
+          client-payload: '{"type": "add_app_testing_from_appsaway", "app_name_list": ${{ toJson(github.event.pull_request.body) }}, "pr_context": ${{  toJson(github.event.pull_request) }}}'

--- a/.github/workflows/updating_PR_body.yml
+++ b/.github/workflows/updating_PR_body.yml
@@ -1,0 +1,17 @@
+name: Updating pr body
+
+on: 
+  repository_dispatch:
+    types: [sending_test_outcome]
+
+jobs:
+  updating_pr_body:
+    runs-on: [ubuntu-latest]
+    steps:
+    - uses: lauracavaliere/pr-update-action@master
+      with:
+        pr-context: "${{ toJson(github.event.client_payload.pr_context) }}"
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        head-branch-regex: 'add_app'
+        body-template: |
+              Test script result\: ${{ github.event.client_payload.test_success }}

--- a/.github/workflows/updating_PR_body.yml
+++ b/.github/workflows/updating_PR_body.yml
@@ -12,6 +12,6 @@ jobs:
       with:
         pr-context: "${{ toJson(github.event.client_payload.pr_context) }}"
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        head-branch-regex: 'add_app'
+        head-branch-regex: 'add_app_\d+'
         body-template: |
               Test script result\: ${{ github.event.client_payload.test_success }}


### PR DESCRIPTION
In this PR two new GitHub Actions have been implemented to handle the pipeline which works to test newly added applications. In particular:
- `triggering_new_app_test.yml` is triggered when a PR on the `add_app_*` branch is opened and sends a repository dispatch to code with the list of the apps to be tested, taken from the PR body, and the pr context;
- `updating_PR_body.yml` is triggered by repository dispatch from code and updates the body of the PR with the outcome of the test received from code. 