### PR TITLE
Update daemon.json to include the nvidia and insecure entries

### DIFF
--- a/scripts/ansible_setup/prepare_cuda.yml
+++ b/scripts/ansible_setup/prepare_cuda.yml
@@ -35,35 +35,38 @@
 
     - name: Initialize JSON structure
       shell: |
-        _is_empty=$( cat /etc/docker/daemon.json | grep "{" )
-        if [[ $_is_empty == "" ]]
+        if [ -s /etc/docker/daemon.json ]
         then
+          echo "File is not empty"
+        else
           echo "{}" > /etc/docker/daemon.json
         fi
       args:
         warn: no
       when: ansible_distribution != 'MacOSX'
-
+      
     - name: Setting up GPUs for Cuda nodes docker configuration
       shell: |
         GPU_ID=`nvidia-smi -a | grep UUID | awk '{print substr($4,0,12)}'` 
         set -- $GPU_ID && GPU_actual=$1
+        echo $GPU_ID
+        echo $GPU_actual
         _has_nvidia_entries=$( cat /etc/docker/daemon.json | grep '"default-runtime": "nvidia"' )
-        if [[ $_has_nvidia_entries == "" ]]
+        if [$_has_nvidia_entries == ""]
         then
           jq '. + {"default-runtime": ("nvidia"), "runtimes": {"nvidia": {"path": ("/usr/bin/nvidia-container-runtime"), "runtimeArgs": []} } }' /etc/docker/daemon.json > daemon_temp.txt
           mv daemon_temp.txt /etc/docker/daemon.json
           echo "edited default runtime"
         fi
         _has_resources=$( cat /etc/docker/daemon.json | grep "node-generic-resources" )
-        if [[ $_has_resources == "" ]]
+        if [$_has_resources == ""]
         then
           jq --arg GPU "gpu=$GPU_actual" '. + {"node-generic-resources": [$GPU]}' /etc/docker/daemon.json > daemon_temp.txt
           mv daemon_temp.txt /etc/docker/daemon.json
           echo "edited resources"
         else
           _has_GPU=$( cat /etc/docker/daemon.json | grep "gpu=$GPU_actual\"" )
-          if [[ $_has_GPU == "" ]]
+          if [$_has_GPU == ""]	
           then
             jq --arg GPU "gpu=$GPU_actual" '."node-generic-resources"[."node-generic-resources"| length] |= . + $GPU' /etc/docker/daemon.json > daemon_temp.txt
             mv daemon_temp.txt /etc/docker/daemon.json

--- a/scripts/ansible_setup/prepare_local_registry.yml
+++ b/scripts/ansible_setup/prepare_local_registry.yml
@@ -17,9 +17,10 @@
 
     - name: Initialize JSON structure
       shell: |
-        _is_empty=$( cat /etc/docker/daemon.json | grep "{" )
-        if [[ $_is_empty == "" ]]
+        if [ -s /etc/docker/daemon.json ]
         then
+          echo "File is not empty"
+        else
           echo "{}" > /etc/docker/daemon.json
         fi
       args:
@@ -30,15 +31,15 @@
       shell: |
         _registry={{ ansible_console_host }}:5000
         _has_insecure_registry=$( cat /etc/docker/daemon.json | grep "insecure-registries" )
-        if [[ $_has_insecure_registry != "" ]]
+        if [$_has_insecure_registry != ""]
         then
-          _has_registry=$( cat /etc/docker/daemon.json | grep $_registry )
-          if [[ $_has_registry == "" ]]
+          _has_registry=$(cat /etc/docker/daemon.json | grep $_registry )
+          if [$_has_registry == ""]
           then
             jq --arg registry "$_registry" '."insecure-registries"[."insecure-registries"| length] |= . + $registry' /etc/docker/daemon.json > daemon_new.txt
             mv daemon_new.txt /etc/docker/daemon.json
             echo "edited registries"
-          fi
+           fi
         else
           jq --arg registry $_registry '. += {"insecure-registries": [$registry] }' /etc/docker/daemon.json > daemon_new.txt
           mv daemon_new.txt /etc/docker/daemon.json


### PR DESCRIPTION
This PR updates the `daemon.json` in order to include the `nvidia configurations` and `insecure entries` as below

```
  {
    "insecure-registries":["10.0.0.1:5000"],
    "default-runtime": "nvidia",
      "runtimes": {
          "nvidia": {
      "path": "/usr/bin/nvidia-container-runtime",
      "runtimeArgs": []
          }
    },
    "node-generic-resources": ["gpu=GPU-d53fc9bd"]
  }
```

The `/etc/docker'/daemon.json` is checked and updated if some entries are missing, otherwise nothing is added.  