### PR TITLE
Restructuring the superviseCalib GUI and its composeHead.yml

### DIFF
--- a/demos/superviseCalib/composeHead.yml
+++ b/demos/superviseCalib/composeHead.yml
@@ -5,10 +5,8 @@ x-yarp-head: &yarp-head
   environment:
     - YARP_FORWARD_LOG_ENABLE=1
     - YARP_ROBOT_NAME
-    - EVENT_CAMERAS
-    - RESOLUTION
-    - EVENT_CAMERA_CONF_FILE
-    - RGB_CAMERA_CONF_FILE
+    - CAMERA_CONF_FILE
+    - CAMERA_CUSTOM_CONF_FILE
   volumes:
     - "${HOME}/${YARP_CONF_PATH}:/root/.config/yarp"
     - "/dev:/dev"

--- a/demos/superviseCalib/composeHead.yml
+++ b/demos/superviseCalib/composeHead.yml
@@ -5,6 +5,10 @@ x-yarp-head: &yarp-head
   environment:
     - YARP_FORWARD_LOG_ENABLE=1
     - YARP_ROBOT_NAME
+    - EVENT_CAMERAS
+    - RESOLUTION
+    - EVENT_CAMERA_CONF_FILE
+    - RGB_CAMERA_CONF_FILE
   volumes:
     - "${HOME}/${YARP_CONF_PATH}:/root/.config/yarp"
     - "/dev:/dev"

--- a/demos/superviseCalib/gui/gui_conf.ini
+++ b/demos/superviseCalib/gui/gui_conf.ini
@@ -8,20 +8,17 @@ ImageName "images/supervise_calib.png"
 toggleButton "" "Custom file" CUSTOM_PATH true/false on unticked
 textEditBox "Specify path:" "" CUSTOM_FILE None on None
 
-toggleButton "" "Rgb cameras" RGB_CAMERAS true/false on unticked
-dropdownList "Resolution:" "" RESOLUTION 320x240/640x480/1024x768 off None
-textEditBox "Specify rgb conf file:" "" RGB_CAMERA_CONF_FILE None on None
-
-toggleButton "" "Event cameras" EVENT_CAMERAS true/false off unticked
-textEditBox "Specify event conf file:" "" EVENT_CAMERA_CONF_FILE None on None
+dropdownList "Choose the type of camera:" "" CAMERA_TYPES Rgb/Event-driven on None
+dropdownList "Choose the resolution:" "" RESOLUTIONS 320x240/640x480/1024x768 on None
+dropdownList "Choose the camera conf file:" "" CAMERA_CONF_FILE ServerGrabberDualDragon.ini/ServerGrabberDualDragonBayer.ini/ServerGrabberDualLeopard.ini on None
+textEditBox "Specify your camera conf file:" "" CAMERA_CUSTOM_CONF_FILE None off None
 toggleButton "" "Mono calibration" MONO_CALIB true/false on unticked
 
 [Button hierarchy]
 Dependency - CUSTOM_FILE - ( {CUSTOM_PATH selected enable} )
-Dependency - EVENT_CAMERAS - ( {RGB_CAMERAS unselected enable} ) 
-Dependency - RGB_CAMERAS - ( {EVENT_CAMERAS unselected enable} ) 
-Dependency - RESOLUTION - ( {RGB_CAMERAS selected enable} )
-Dependency - START_BUTTON - ( ( {RGB_CAMERAS selected enable} && ( {RESOLUTION 320x240 enable} || ( {RESOLUTION 640x480 enable} && {RGB_CAMERA_CONF_FILE selected enable} ) || ( {RESOLUTION 1024x768 enable} && {RGB_CAMERA_CONF_FILE selected enable} ) ) )  || ( {EVENT_CAMERAS selected enable} && {EVENT_CAMERA_CONF_FILE selected enable} ) )
-Dependency - RGB_CAMERA_CONF_FILE - ( {RGB_CAMERAS selected enable} ) 
-Dependency - EVENT_CAMERA_CONF_FILE - ( {EVENT_CAMERAS selected enable} ) 
+Dependency - CAMERA_CUSTOM_CONF_FILE - ( {CAMERA_CONF_FILE Custom-file enable} )
+Dependency - START_BUTTON - ( ( {CAMERA_TYPES Rgb enable} || {CAMERA_TYPES Event-driven enable} ) && ( {RESOLUTIONS 320x240/640x480/1024x768/304x240 enable} && {CAMERA_CONF_FILE Custom-file disable} ) || ( {CAMERA_CUSTOM_CONF_FILE selected enable} && {CAMERA_CONF_FILE Custom-file enable} ) )
 
+[Button Options]
+OptionList - RESOLUTIONS - CAMERA_TYPES [Rgb/Event-driven] [[320x240/640x480/1024x768],[304x240]]
+OptionList - CAMERA_CONF_FILE - RESOLUTIONS [320x240/640x480/1024x768/304x240] [[ServerGrabberDualDragon.ini/ServerGrabberDualDragonBayer.ini/ServerGrabberDualLeopard.ini/Custom-file],[ServerGrabberDualDragonBayer640_480.ini/Custom-file],[Custom-file],[ATIS_stereo.ini/Custom-file]]

--- a/demos/superviseCalib/gui/gui_conf.ini
+++ b/demos/superviseCalib/gui/gui_conf.ini
@@ -6,12 +6,14 @@ ImageName "images/supervise_calib.png"
  
 [right options]
 toggleButton "" "Custom file" CUSTOM_PATH true/false on unticked
-textEditBox "Specify file:" "" CUSTOM_FILE None on None
+textEditBox "Specify path:" "" CUSTOM_FILE None on None
 
 toggleButton "" "Rgb cameras" RGB_CAMERAS true/false on unticked
 dropdownList "Resolution:" "" RESOLUTION 320x240/640x480/1024x768 off None
+textEditBox "Specify rgb conf file:" "" RGB_CAMERA_CONF_FILE None on None
 
 toggleButton "" "Event cameras" EVENT_CAMERAS true/false off unticked
+textEditBox "Specify event conf file:" "" EVENT_CAMERA_CONF_FILE None on None
 toggleButton "" "Mono calibration" MONO_CALIB true/false on unticked
 
 [Button hierarchy]
@@ -19,4 +21,7 @@ Dependency - CUSTOM_FILE - ( {CUSTOM_PATH selected enable} )
 Dependency - EVENT_CAMERAS - ( {RGB_CAMERAS unselected enable} ) 
 Dependency - RGB_CAMERAS - ( {EVENT_CAMERAS unselected enable} ) 
 Dependency - RESOLUTION - ( {RGB_CAMERAS selected enable} )
-Dependency - START_BUTTON - ( {RGB_CAMERAS selected enable} || {EVENT_CAMERAS selected enable} )
+Dependency - START_BUTTON - ( ( {RGB_CAMERAS selected enable} && ( {RESOLUTION 320x240 enable} || ( {RESOLUTION 640x480 enable} && {RGB_CAMERA_CONF_FILE selected enable} ) || ( {RESOLUTION 1024x768 enable} && {RGB_CAMERA_CONF_FILE selected enable} ) ) )  || ( {EVENT_CAMERAS selected enable} && {EVENT_CAMERA_CONF_FILE selected enable} ) )
+Dependency - RGB_CAMERA_CONF_FILE - ( {RGB_CAMERAS selected enable} ) 
+Dependency - EVENT_CAMERA_CONF_FILE - ( {EVENT_CAMERAS selected enable} ) 
+

--- a/demos/superviseCalib/main.yml
+++ b/demos/superviseCalib/main.yml
@@ -7,8 +7,8 @@ x-yarp-base: &yarp-base
     - YARP_ROBOT_NAME
     - APPSAWAY_CALIB_CONTEXT
     - CUSTOM_FILE
-    - EVENT_CAMERAS
-    - RESOLUTION
+    - CAMERA_TYPES
+    - RESOLUTIONS
     - MONO_CALIB
   volumes:
     - "${HOME}/${YARP_CONF_PATH}:/root/.config/yarp"
@@ -41,7 +41,7 @@ services:
         constraints: [node.labels.type != head]
       restart_policy:
         condition: on-failure
-    command: sh -c "yarp wait /viewer_template; if [ ${MONO_CALIB} = false ]; then if [ ${EVENT_CAMERAS} = true ]; then calibSupervisor --file calibrations_event_304x240.ini --eventCam true --percentageThresh 86.0; else if [ ${RESOLUTION} = "320x240" ]; then calibSupervisor; else if [ ${RESOLUTION} = "640x480" ]; then calibSupervisor --file calibrations_rgb_640x480.ini; else if [ ${RESOLUTION} = "1024x768" ]; then calibSupervisor --file calibrations_rgb_1024x768.ini; fi; fi; fi; fi; else if [ ${EVENT_CAMERAS} = true ]; then calibSupervisor --file calibrations_event_304x240.ini --eventCam true --stereo false --percentageThresh 86.0; else if [ ${RESOLUTION} = "320x240" ]; then calibSupervisor --stereo false; else if [ ${RESOLUTION} = "640x480" ]; then calibSupervisor --file calibrations_rgb_640x480.ini --stereo false; else if [ ${RESOLUTION} = "1024x768" ]; then calibSupervisor --file calibrations_rgb_1024x768.ini --stereo false; fi; fi; fi; fi; fi;"
+    command: sh -c "yarp wait /viewer_template; if [ ${MONO_CALIB} = false ]; then if [ ${CAMERA_TYPES} = "Event-driven" ]; then calibSupervisor --file calibrations_event_304x240.ini --eventCam true --percentageThresh 86.0; else if [ ${RESOLUTIONS} = "320x240" ]; then calibSupervisor; else if [ ${RESOLUTIONS} = "640x480" ]; then calibSupervisor --file calibrations_rgb_640x480.ini; else if [ ${RESOLUTIONS} = "1024x768" ]; then calibSupervisor --file calibrations_rgb_1024x768.ini; fi; fi; fi; fi; else if [ ${CAMERA_TYPES} = "Event-driven" ]; then calibSupervisor --file calibrations_event_304x240.ini --eventCam true --stereo false --percentageThresh 86.0; else if [ ${RESOLUTIONS} = "320x240" ]; then calibSupervisor --stereo false; else if [ ${RESOLUTIONS} = "640x480" ]; then calibSupervisor --file calibrations_rgb_640x480.ini --stereo false; else if [ ${RESOLUTIONS} = "1024x768" ]; then calibSupervisor --file calibrations_rgb_1024x768.ini --stereo false; fi; fi; fi; fi; fi;"
 
   yUpdateFile:
     <<: *yarp-base
@@ -71,7 +71,7 @@ services:
         constraints: [node.labels.type != head]
       restart_policy:
         condition: on-failure
-    command: sh -c "if [ ${EVENT_CAMERAS} = true ]; then yarp wait /vFramer/left/image:o; else yarp wait /icub/cam/left; fi; yarp wait /viewer/left ; if [ ${EVENT_CAMERAS} = true ]; then yarp connect /vFramer/left/image:o /viewer/left fast_tcp; else yarp connect /icub/cam/left /viewer/left fast_tcp; fi;"
+    command: sh -c "if [ ${CAMERA_TYPES} = "Event-driven" ]; then yarp wait /vFramer/left/image:o; else yarp wait /icub/cam/left; fi; yarp wait /viewer/left ; if [ ${CAMERA_TYPES} = "Event-driven" ]; then yarp connect /vFramer/left/image:o /viewer/left fast_tcp; else yarp connect /icub/cam/left /viewer/left fast_tcp; fi;"
 
   yConnectToRightRaw:
     <<: *yarp-base
@@ -80,7 +80,7 @@ services:
         constraints: [node.labels.type != head]
       restart_policy:
         condition: on-failure
-    command: sh -c "if [ ${EVENT_CAMERAS} = true ]; then yarp wait /vFramer/right/image:o; else yarp wait /icub/cam/right; fi; yarp wait /viewer/right ; if [ ${EVENT_CAMERAS} = true ]; then yarp connect /vFramer/right/image:o /viewer/right fast_tcp; else yarp connect /icub/cam/right /viewer/right fast_tcp; fi;"
+    command: sh -c "if [ ${CAMERA_TYPES} = "Event-driven" ]; then yarp wait /vFramer/right/image:o; else yarp wait /icub/cam/right; fi; yarp wait /viewer/right ; if [ ${CAMERA_TYPES} = "Event-driven" ]; then yarp connect /vFramer/right/image:o /viewer/right fast_tcp; else yarp connect /icub/cam/right /viewer/right fast_tcp; fi;"
 
   yConnectToLeftInImage:
     <<: *yarp-base
@@ -89,7 +89,7 @@ services:
         constraints: [node.labels.type != head]
       restart_policy:
         condition: on-failure
-    command: sh -c "if [ ${EVENT_CAMERAS} = true ]; then yarp wait /vFramer/left/image:o; else yarp wait /icub/cam/left; fi; yarp wait /calibSupervisor/imageLeft:i ; if [ ${EVENT_CAMERAS} = true ]; then yarp connect /vFramer/left/image:o /calibSupervisor/imageLeft:i fast_tcp; else yarp connect /icub/cam/left /calibSupervisor/imageLeft:i fast_tcp; fi;"
+    command: sh -c "if [ ${CAMERA_TYPES} = "Event-driven" ]; then yarp wait /vFramer/left/image:o; else yarp wait /icub/cam/left; fi; yarp wait /calibSupervisor/imageLeft:i ; if [ ${CAMERA_TYPES} = "Event-driven" ]; then yarp connect /vFramer/left/image:o /calibSupervisor/imageLeft:i fast_tcp; else yarp connect /icub/cam/left /calibSupervisor/imageLeft:i fast_tcp; fi;"
 
 
   yConnectToRightInImage:
@@ -99,7 +99,7 @@ services:
         constraints: [node.labels.type != head]
       restart_policy:
         condition: on-failure
-    command: sh -c "if [ ${EVENT_CAMERAS} = true ]; then yarp wait /vFramer/right/image:o; else yarp wait /icub/cam/right; fi; yarp wait /calibSupervisor/imageRight:i ; if [ ${EVENT_CAMERAS} = true ]; then yarp connect /vFramer/right/image:o; /calibSupervisor/imageRight:i fast_tcp; else yarp connect /icub/cam/right /calibSupervisor/imageRight:i fast_tcp; fi;"
+    command: sh -c "if [ ${CAMERA_TYPES} = "Event-driven" ]; then yarp wait /vFramer/right/image:o; else yarp wait /icub/cam/right; fi; yarp wait /calibSupervisor/imageRight:i ; if [ ${CAMERA_TYPES} = "Event-driven" ]; then yarp connect /vFramer/right/image:o; /calibSupervisor/imageRight:i fast_tcp; else yarp connect /icub/cam/right /calibSupervisor/imageRight:i fast_tcp; fi;"
 
   yConnectToLeftStereoCalib:
     <<: *yarp-base
@@ -144,7 +144,7 @@ services:
         constraints: [node.labels.type != head]
       restart_policy:
         condition: on-failure
-    command: sh -c "if [ ${EVENT_CAMERAS} = true ]; then yarp wait /vFramer/left/image:o; else yarp wait /icub/cam/left ; fi; yarp wait /camCalib/left/in; if [ ${EVENT_CAMERAS} = true ]; then yarp connect /vFramer/left/image:o /camCalib/left/in fast_tcp ; else yarp connect /icub/cam/left /camCalib/left/in fast_tcp ; fi;"
+    command: sh -c "if [ ${CAMERA_TYPES} = "Event-driven" ]; then yarp wait /vFramer/left/image:o; else yarp wait /icub/cam/left ; fi; yarp wait /camCalib/left/in; if [ ${CAMERA_TYPES} = "Event-driven" ]; then yarp connect /vFramer/left/image:o /camCalib/left/in fast_tcp ; else yarp connect /icub/cam/left /camCalib/left/in fast_tcp ; fi;"
   
   yConnectToRightInCamCalib:
     <<: *yarp-base
@@ -153,7 +153,7 @@ services:
         constraints: [node.labels.type != head]
       restart_policy:
         condition: on-failure
-    command: sh -c "if [ ${EVENT_CAMERAS} = true ]; then yarp wait /vFramer/right/image:o; else yarp wait /icub/cam/right ; fi; yarp wait /camCalib/right/in; if [ ${EVENT_CAMERAS} = true ]; then yarp connect /vFramer/right/image:o /camCalib/right/in fast_tcp ; else yarp connect /icub/cam/right /camCalib/right/in fast_tcp ; fi;"
+    command: sh -c "if [ ${CAMERA_TYPES} = "Event-driven" ]; then yarp wait /vFramer/right/image:o; else yarp wait /icub/cam/right ; fi; yarp wait /camCalib/right/in; if [ ${CAMERA_TYPES} = "Event-driven" ]; then yarp connect /vFramer/right/image:o /camCalib/right/in fast_tcp ; else yarp connect /icub/cam/right /camCalib/right/in fast_tcp ; fi;"
 
   yConnectToLeftOutCamCalib:
     <<: *yarp-base
@@ -186,7 +186,7 @@ services:
 
   #use network.peer ip address and port 8080 to see the containers status in browser
   visualizer:
-    image: dockersamples/visualizer:stable
+    image: localhost:5000/test
     ports:
       - "8080:8080"
     volumes:

--- a/demos/superviseCalib/main.yml
+++ b/demos/superviseCalib/main.yml
@@ -186,7 +186,7 @@ services:
 
   #use network.peer ip address and port 8080 to see the containers status in browser
   visualizer:
-    image: localhost:5000/test
+    image: dockersamples/visualizer:stable
     ports:
       - "8080:8080"
     volumes:

--- a/gui/main.py
+++ b/gui/main.py
@@ -549,6 +549,9 @@ class WidgetGallery(QDialog):
                   buttonOption.button.clear()
                   for new_item in opt_list:
                     buttonOption.button.addItem(new_item)
+                  buttonOption.button.setCurrentIndex(0)
+                  for button in self.button_list: # check the status of all buttons
+                    self.checkDependencies(button)
  
     
     @pyqtSlot()


### PR DESCRIPTION
With this PR we restructured the GUI in order to give the possibility to the user of choosing:
- the type of camera: rgb or event-driven
- the resolution (320x240, 640x480, 1024x768)
- the camera configuration file used to start the driver: for each type of camera and resolution, the user can select one of the proposed `.ini` files from the drop-down list. There, you also find a custom-file: if this option is selected, a text field is enabled and here the user must insert his custom file in order to start the application.

Moreover, we adapted the `composeHead.yml` to this new structure of the GUI, and now it covers all the cases to start the device in a clearer way: if the custom field is empty, we run the device with the file selected from the drop-down list, otherwise, we take the custom one.