### PR TITLE
[faceAndPoseDetection] fixing image name

### DIFF
--- a/demos/faceAndPoseDetection/main.yml
+++ b/demos/faceAndPoseDetection/main.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-demo: &yarp-demo
-  image: icubteamcode/human-sensing:master_master-unstable_sources #this image name still need to be changed into face-and-pose-detection
+  image: icubteamcode/human-sensing:master-stable_master_sources
   environment:
     - DISPLAY=${DISPLAY}
     - QT_X11_NO_MITSHM=1


### PR DESCRIPTION
This PR contiains changes to the image name of the YML deployment files. The current name is failing for the test of the apps as the manifest does not exists