### PR TITLE
Added Volume for sharing scripts and files 

### DIFF
--- a/demos/funnyThingsApp/composeGui.yml
+++ b/demos/funnyThingsApp/composeGui.yml
@@ -12,6 +12,7 @@ x-yarp-base: &yarp-base
     - "${XAUTHORITY}:/root/.Xauthority"
     - "${HOME}/${YARP_CONF_PATH}:/root/.config/yarp"
     - "/dev:/dev"
+    - "${HOME}:/root"
   network_mode: "host"
   privileged: true
 

--- a/demos/funnyThingsApp/src/renderer.js
+++ b/demos/funnyThingsApp/src/renderer.js
@@ -565,7 +565,7 @@ const generateFullFilename = (filename) => {
 const exportActivities = () => {
     saveTextFile(JSON.stringify(activitiesToPerform, null, 2),
     'Save your activites',
-    '~/mydemo.funnythings',
+    path.join(process.env.HOME, 'mydemo.funnythings'),
     'Save',
     'Funny Things Demos',
     ['funnythings'])
@@ -575,6 +575,7 @@ const importActivities = () => {
     dialog.showOpenDialog(remote.getCurrentWindow(),{
         properties: ['openFile'],
         buttonLabel: 'Load',
+        defaultPath: process.env.HOME,
         filters: [
             {
                 name: 'Funny Things Demos',
@@ -665,7 +666,7 @@ const bashExporter = ()=>{
 
             saveTextFile(newFunnyThingScriptContent,
                 'Save your bash script',
-                '~/mydemoscript.sh',
+                path.join(process.env.HOME, 'mydemo.sh'),
                 'Save',
                 'Shell scripts',
                 ['sh']);


### PR DESCRIPTION
Alongside @Nicogene we added the shared volume of HOME, as per [this](https://github.com/icub-tech-iit/code/issues/775#issuecomment-937848871) comment, in the `composeGui.yml` of `funnyThings`

We also updated the funnyThings app to use as base its HOME directory when importing or exporting. This means that when you open the import and export dialogs, they begin from the shared volume.

Before merging we must discuss if this approach really is safe in relation to the rest of the deployment, particularly with regards of `appsAway_changeNewFilesPermissions.sh`.

cc @vtikha @vvasco @AlexAntn 
