### PR TITLE
Updated image tags with the last release in all the .ymls

### DIFF
--- a/demos/cameraTiltCalib/composeGui.yml
+++ b/demos/cameraTiltCalib/composeGui.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/supervise-calib:v2021.02.feat-01-stable_master_binaries
+  image: icubteamcode/supervise-calib:v2021.08.1-stable_master_sources
   environment:
     - DISPLAY=${DISPLAY}
     - XAUTHORITY=/root/.Xauthority

--- a/demos/cameraTiltCalib/composeHead.yml
+++ b/demos/cameraTiltCalib/composeHead.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/superbuild-icubhead:v2021.02.feat-01-stable_master_binaries
+  image: icubteamcode/superbuild-icubhead:v2021.08.1-stable_master_sources
   environment:
     - YARP_FORWARD_LOG_ENABLE=1
     - YARP_ROBOT_NAME

--- a/demos/cameraTiltCalib/main.yml
+++ b/demos/cameraTiltCalib/main.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/supervise-calib:master_master-unstable_sources
+  image: icubteamcode/supervise-calib:v2021.08.1-stable_master_sources 
   environment:
     - YARP_FORWARD_LOG_ENABLE=1
     - LEFT_CUSTOM_PORT

--- a/demos/faceAndPoseDetection/composeGui.yml
+++ b/demos/faceAndPoseDetection/composeGui.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/human-sensing:master-stable_master_sources
+  image: icubteamcode/human-sensing:v2021.08.1-stable_master_sources
   environment:
     - DISPLAY=${DISPLAY}
     - QT_X11_NO_MITSHM=1

--- a/demos/faceAndPoseDetection/composeHead.yml
+++ b/demos/faceAndPoseDetection/composeHead.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-head: &yarp-head
-  image: icubteamcode/superbuild-icubhead:master-unstable_binaries
+  image: icubteamcode/superbuild-icubhead:v2021.08.1-stable_master_sources
   environment:
     - YARP_FORWARD_LOG_ENABLE=1
     - YARP_ROBOT_NAME

--- a/demos/faceAndPoseDetection/main.yml
+++ b/demos/faceAndPoseDetection/main.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-demo: &yarp-demo
-  image: icubteamcode/human-sensing:master-stable_master_sources
+  image: icubteamcode/human-sensing:v2021.08.1-stable_master_sources
   environment:
     - DISPLAY=${DISPLAY}
     - QT_X11_NO_MITSHM=1

--- a/demos/funnyThingsApp/composeGui.yml
+++ b/demos/funnyThingsApp/composeGui.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/funny-things:master-unstable_master_binaries
+  image: icubteamcode/funny-things:v2021.08.1-stable_master_sources
   environment:
     - DISPLAY=${DISPLAY}
     - XAUTHORITY=/root/.Xauthority
@@ -17,7 +17,7 @@ x-yarp-base: &yarp-base
   privileged: true
 
 x-yarp-speech: &yarp-speech
-  image: icubteamcode/speech:master-unstable_master_binaries
+  image: icubteamcode/speech:v2021.08.1-stable_master_sources
   environment:
     - DISPLAY=${DISPLAY}
     - XAUTHORITY=/root/.Xauthority

--- a/demos/funnyThingsApp/main.yml
+++ b/demos/funnyThingsApp/main.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/funny-things:master-unstable_master_binaries
+  image: icubteamcode/funny-things:v2021.08.1-stable_master_sources
   environment:
     - DISPLAY=${DISPLAY}
     - QT_X11_NO_MITSHM=1

--- a/demos/googleDialog/composeGui.yml
+++ b/demos/googleDialog/composeGui.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/speech:master_master-unstable_sources
+  image: icubteamcode/speech:v2021.08.1-stable_master_sources
   environment:
     - DISPLAY=${DISPLAY}
     - QT_X11_NO_MITSHM=1

--- a/demos/googleDialog/main.yml
+++ b/demos/googleDialog/main.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/speech:master_master-unstable_sources
+  image: icubteamcode/speech:v2021.08.1-stable_master_sources
   environment:
     - DISPLAY=${DISPLAY}
     - QT_X11_NO_MITSHM=1

--- a/demos/googleSpeechApp/composeGui.yml
+++ b/demos/googleSpeechApp/composeGui.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/speech:v2020.08.patch-01_master-unstable_sources
+  image: icubteamcode/speech:v2021.08.1-stable_master_sources
   environment:
     - DISPLAY=${DISPLAY}
     - QT_X11_NO_MITSHM=1

--- a/demos/googleSpeechApp/main.yml
+++ b/demos/googleSpeechApp/main.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/speech:v2020.08.patch-01_master-unstable_sources
+  image: icubteamcode/speech:v2021.08.1-stable_master_sources
   environment:
     - DISPLAY=${DISPLAY}
     - QT_X11_NO_MITSHM=1

--- a/demos/googleSpeechProcessing/composeGui.yml
+++ b/demos/googleSpeechProcessing/composeGui.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/speech:master_master-unstable_sources
+  image: icubteamcode/speech:v2021.08.1-stable_master_sources
   environment:
     - DISPLAY=${DISPLAY}
     - QT_X11_NO_MITSHM=1

--- a/demos/googleSpeechProcessing/main.yml
+++ b/demos/googleSpeechProcessing/main.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/speech:master_master-unstable_sources
+  image: icubteamcode/speech:v2021.08.1-stable_master_sources
   environment:
     - DISPLAY=${DISPLAY}
     - QT_X11_NO_MITSHM=1

--- a/demos/googleVisionAI/composeGui.yml
+++ b/demos/googleVisionAI/composeGui.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/google-vision:master_master-unstable_sources
+  image: icubteamcode/google-vision:v2021.08.1-stable_master_sources
   environment:
     - DISPLAY=${DISPLAY}
     - XAUTHORITY=/root/.Xauthority

--- a/demos/googleVisionAI/main.yml
+++ b/demos/googleVisionAI/main.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/google-vision:master_master-unstable_sources
+  image: icubteamcode/google-vision:v2021.08.1-stable_master_sources
   environment:
     - YARP_FORWARD_LOG_ENABLE=1
     - FILE_INPUT

--- a/demos/graspTheBall/composeGui.yml
+++ b/demos/graspTheBall/composeGui.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/grasp-the-ball:v2021.02.feat-01_master-stable_binaries
+  image: icubteamcode/grasp-the-ball:v2021.08.1-stable_master_sources
   environment:
     - DISPLAY=${DISPLAY}
     - QT_X11_NO_MITSHM=1

--- a/demos/graspTheBall/composeHead.yml
+++ b/demos/graspTheBall/composeHead.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-head: &yarp-head
-  image: icubteamcode/superbuild-icubhead:master-unstable_binaries
+  image: icubteamcode/superbuild-icubhead:v2021.08.1-stable_master_sources
   environment:
     - YARP_FORWARD_LOG_ENABLE=1
     - YARP_ROBOT_NAME

--- a/demos/graspTheBall/main.yml
+++ b/demos/graspTheBall/main.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/grasp-the-ball:v2021.02.feat-01_master-stable_sources
+  image: icubteamcode/grasp-the-ball:v2021.08.1-stable_master_sources
   environment:
     - DISPLAY=${DISPLAY}
     - QT_X11_NO_MITSHM=1

--- a/demos/graspTheBallGazebo/composeGui.yml
+++ b/demos/graspTheBallGazebo/composeGui.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-gazebo: &yarp-gazebo
-  image: icubteamcode/grasp-the-ball-gazebo:devel_master-unstable_sources
+  image: icubteamcode/grasp-the-ball-gazebo:master_sources
   environment:
     - DISPLAY=${DISPLAY}
     - QT_X11_NO_MITSHM=1

--- a/demos/graspTheBallGazebo/main.yml
+++ b/demos/graspTheBallGazebo/main.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/grasp-the-ball-gazebo:devel_master-unstable_sources
+  image: icubteamcode/grasp-the-ball-gazebo:master_sources
   environment:
     - DISPLAY=${DISPLAY}
     - QT_X11_NO_MITSHM=1

--- a/demos/iCubGazeboGrasping/composeGui.yml
+++ b/demos/iCubGazeboGrasping/composeGui.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/grasp-gazebo:master_master-unstable_sources
+  image: icubteamcode/grasp-gazebo:master_sources
   environment:
     - DISPLAY=${DISPLAY}
     - QT_X11_NO_MITSHM=1

--- a/demos/iCubGazeboGrasping/main.yml
+++ b/demos/iCubGazeboGrasping/main.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/grasp-gazebo:master_master-unstable_sources
+  image: icubteamcode/grasp-gazebo:master_sources
   environment:
     - DISPLAY=${DISPLAY}
     - QT_X11_NO_MITSHM=1

--- a/demos/robotBaseStartup/composeHead.yml
+++ b/demos/robotBaseStartup/composeHead.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-head: &yarp-head
-  image: icubteamcode/superbuild-icubhead:master-unstable_binaries
+  image: icubteamcode/superbuild-icubhead:v2021.08.1-stable_master_sources
   environment:
     - YARP_FORWARD_LOG_ENABLE=1
     - YARP_ROBOT_NAME

--- a/demos/robotBaseStartup/main.yml
+++ b/demos/robotBaseStartup/main.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/superbuild:master-unstable_binaries
+  image: icubteamcode/superbuild:v2021.08.1-stable_master_sources
   environment:
     - DISPLAY=${DISPLAY}
     - QT_X11_NO_MITSHM=1

--- a/demos/robotGazebo/composeGui.yml
+++ b/demos/robotGazebo/composeGui.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/superbuild-gazebo:master-unstable_sources
+  image: icubteamcode/superbuild-gazebo:v2021.08.1-stable_master_sources
   environment:
     - DISPLAY=${DISPLAY}
     - QT_X11_NO_MITSHM=1

--- a/demos/robotGazebo/main.yml
+++ b/demos/robotGazebo/main.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/superbuild-gazebo:master-unstable_sources  
+  image: icubteamcode/superbuild-gazebo:v2021.08.1-stable_master_sources
   environment:
     - DISPLAY=${DISPLAY}
     - QT_X11_NO_MITSHM=1

--- a/demos/speechToText/composeGui.yml
+++ b/demos/speechToText/composeGui.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/speech:master_master-unstable_sources
+  image: icubteamcode/speech:v2021.08.1-stable_master_sources
   environment:
     - DISPLAY=${DISPLAY}
     - QT_X11_NO_MITSHM=1

--- a/demos/speechToText/main.yml
+++ b/demos/speechToText/main.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/speech:master_master-unstable_sources
+  image: icubteamcode/speech:v2021.08.1-stable_master_sources
   environment:
     - DISPLAY=${DISPLAY}
     - QT_X11_NO_MITSHM=1

--- a/demos/startQA/composeGui.yml
+++ b/demos/startQA/composeGui.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/speech:master_master-unstable_sources
+  image: icubteamcode/speech:v2021.08.1-stable_master_sources
   environment:
     - DISPLAY=${DISPLAY}
     - XAUTHORITY=/root/.Xauthority

--- a/demos/startQA/main.yml
+++ b/demos/startQA/main.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/speech:master_master-unstable_sources
+  image: icubteamcode/speech:v2021.08.1-stable_master_sources
   environment:
     - DISPLAY=${DISPLAY}
     - QT_X11_NO_MITSHM=1

--- a/demos/superviseCalib/composeGui.yml
+++ b/demos/superviseCalib/composeGui.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/supervise-calib:master_master-unstable_sources
+  image: icubteamcode/supervise-calib:v2021.08.1-stable_master_sources
   environment:
     - DISPLAY=${DISPLAY}
     - XAUTHORITY=/root/.Xauthority

--- a/demos/superviseCalib/composeHead.yml
+++ b/demos/superviseCalib/composeHead.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-head: &yarp-head
-  image: icubteamcode/superbuild-icubhead:master_master-unstable_sources
+  image: icubteamcode/superbuild-icubhead:v2021.08.1-stable_master_sources
   environment:
     - YARP_FORWARD_LOG_ENABLE=1
     - YARP_ROBOT_NAME

--- a/demos/superviseCalib/main.yml
+++ b/demos/superviseCalib/main.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/supervise-calib:master_master-unstable_sources
+  image: icubteamcode/supervise-calib:v2021.08.1-stable_master_sources
   environment:
     - YARP_FORWARD_LOG_ENABLE=1
     - YARP_ROBOT_NAME

--- a/demos/textToSpeech/composeGui.yml
+++ b/demos/textToSpeech/composeGui.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/speech:master_master-unstable_sources
+  image: icubteamcode/speech:v2021.08.1-stable_master_sources
   environment:
     - DISPLAY=${DISPLAY}
     - XAUTHORITY=/root/.Xauthority

--- a/demos/textToSpeech/main.yml
+++ b/demos/textToSpeech/main.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/speech:master_master-unstable_sources
+  image: icubteamcode/speech:v2021.08.1-stable_master_sources
   environment:
     - DISPLAY=${DISPLAY}
     - QT_X11_NO_MITSHM=1

--- a/demos/yarpBasicDeploy/composeGui.yml
+++ b/demos/yarpBasicDeploy/composeGui.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-gui
-  image: icubteamcode/superbuild:master-unstable_master_binaries
+  image: icubteamcode/superbuild:v2021.08.1-stable_master_sources
   environment:
     - DISPLAY=${DISPLAY}
     - QT_X11_NO_MITSHM=1

--- a/demos/yarpBasicDeploy/composeHead.yml
+++ b/demos/yarpBasicDeploy/composeHead.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-head: &yarp-head
-  image: icubteamcode/superbuild-icubhead:master-unstable_binaries
+  image: icubteamcode/superbuild-icubhead:v2021.08.1-stable_master_sources
   environment:
     - YARP_FORWARD_LOG_ENABLE=1
     - YARP_ROBOT_NAME

--- a/demos/yarpBasicDeploy/main.yml
+++ b/demos/yarpBasicDeploy/main.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/superbuild:master-unstable_master_binaries
+  image: icubteamcode/superbuild:v2021.08.1-stable_master_sources
   environment:
     - DISPLAY=${DISPLAY}
     - QT_X11_NO_MITSHM=1

--- a/demos/yarpOpenFace/composeGui.yml
+++ b/demos/yarpOpenFace/composeGui.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/open-face:master-unstable_sources
+  image: icubteamcode/open-face:v2021.08.1-stable_master_sources
   environment:
     - DISPLAY=${DISPLAY}
     - QT_X11_NO_MITSHM=1

--- a/demos/yarpOpenFace/composeHead.yml
+++ b/demos/yarpOpenFace/composeHead.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-head: &yarp-head
-  image: icubteamcode/superbuild-icubhead:master-unstable_sources
+  image: icubteamcode/superbuild-icubhead:v2021.08.1-stable_master_sources
   environment:
     - YARP_FORWARD_LOG_ENABLE=1
     - YARP_ROBOT_NAME

--- a/demos/yarpOpenFace/main.yml
+++ b/demos/yarpOpenFace/main.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 x-yarp-base: &yarp-base
-  image: icubteamcode/open-face:master-unstable_sources
+  image: icubteamcode/open-face:v2021.08.1-stable_master_sources
   environment:
     - DISPLAY=${DISPLAY}
     - QT_X11_NO_MITSHM=1


### PR DESCRIPTION
With this PR we want to update the images tags with the last release (`v2021.08.1-stable_master_sources`) in the `.ymls` of all appsAway demos.

Some demos were not been updated with the new image tag versioning in the deployment (e.g.  `graspTheBallGazebo` had `icubteamcode/grasp-the-ball-gazebo:devel_master-unstable_sources`).

This implied that the .ymls would not have worked if run manually since the image with that specific tag was not existing on DockerHub.