### PR TITLE
Fix 762

### DIFF
--- a/scripts/appsAway_registryLaunch.yml
+++ b/scripts/appsAway_registryLaunch.yml
@@ -1,0 +1,15 @@
+version: "3.7"
+
+services:
+    myregistry:
+        image: "registry:2"
+        networks:
+            - hostnet
+        expose:
+            - "5000"
+            
+networks:
+    hostnet:
+        external: true
+        name: host
+

--- a/scripts/appsAway_setupCluster.sh
+++ b/scripts/appsAway_setupCluster.sh
@@ -349,8 +349,9 @@ find_docker_images()
   then     
     REGISTRY_UP_FLAG=false
     echo "Creating the local registry"
-    ${_DOCKER_BIN} service create --constraint node.role==manager --name registry \
-    --publish published=5000,target=5000 --replicas 1 registry:2 
+    ${_DOCKER_BIN} stack deploy -c appsAway_registryLaunch.yml ${APPSAWAY_STACK_NAME}
+  #  ${_DOCKER_BIN} service create --constraint node.role==manager --name registry \
+  #  --publish published=5000,target=5000 --replicas 1 registry:2 
   else
     return=$(${_DOCKER_BIN} service ls | grep "*:5000->5000/tcp")
     if [[ $return != "" ]]


### PR DESCRIPTION
Fixed by launching the registry as a service specifying `host` network as we already did for all other services.

Added the new file `scripts/appsAway_registryLaunch.yml` (registry deploy file) and modified the [command](https://github.com/icub-tech-iit/appsAway/pull/241/commits/a0d0fd37461324f2a1630811761fcd40d5ce2b46) to launch the registry service.

cc @AlexAntn 