### PR TITLE
Removed wrong read and write flag 

### DIFF
--- a/.ci/docker-yarpbasic.yml
+++ b/.ci/docker-yarpbasic.yml
@@ -5,8 +5,8 @@ x-yarp-base: &yarp-base
   network_mode: bridge
   volumes: 
     - "${GITHUB_WORKSPACE}/.ci/:/outcome"
-    - "/tmp/.X11-unix:/tmp/.X11-unix:rw"
-    - "${XAUTHORITY}:/root/.Xauthority:rw"
+    - "/tmp/.X11-unix:/tmp/.X11-unix"
+    - "${XAUTHORITY}:/root/.Xauthority"
   environment:
     - DISPLAY=${DISPLAY}
     - QT_X11_NO_MITSHM=1

--- a/.ci/docker-yarpgazebo.yml
+++ b/.ci/docker-yarpgazebo.yml
@@ -5,7 +5,7 @@ x-yarp-base: &yarp-base
   network_mode: bridge
   volumes: 
     - "${GITHUB_WORKSPACE}/.ci/:/outcome"
-    - "/tmp/.X11-unix:/tmp/.X11-unix:rw"
+    - "/tmp/.X11-unix:/tmp/.X11-unix"
   environment:
     - DISPLAY=${DISPLAY}
     - QT_X11_NO_MITSHM=1
@@ -23,4 +23,4 @@ services:
         - yarp-server      
       command: gazebo
       
-#    - "${XAUTHORITY}:/root/.Xauthority:rw"
+#    - "${XAUTHORITY}:/root/.Xauthority"

--- a/demos/graspTheBall/main.yml
+++ b/demos/graspTheBall/main.yml
@@ -16,7 +16,7 @@ x-yarp-base: &yarp-base
     - "/tmp/.X11-unix:/tmp/.X11-unix"
     - "${XAUTHORITY}:/root/.Xauthority"
     - "${HOME}/${YARP_CONF_PATH}:/root/.config/yarp"
-    - "${APPSAWAY_DEMOREDBALL_CONTEXT}:/usr/local/share/ICUBcontrib/contexts/demoRedBall/:rw"
+    - "${APPSAWAY_DEMOREDBALL_CONTEXT}:/usr/local/share/ICUBcontrib/contexts/demoRedBall/"
   networks:
     - hostnet
 

--- a/demos/superviseCalib/main.yml
+++ b/demos/superviseCalib/main.yml
@@ -13,8 +13,8 @@ x-yarp-base: &yarp-base
   volumes:
     - "${HOME}/${YARP_CONF_PATH}:/root/.config/yarp"
     - "${APPSAWAY_CALIB_CONTEXT}:/usr/local/share/iCub/contexts/cameraCalibration/:rw"
-    - "${APPSAWAY_CALIB_CONTEXT}/icubEyes.ini:/usr/local/share/ICUBcontrib/robots/${YARP_ROBOT_NAME}/icubEyes.ini:rw"
-    - "${ICUB_EYES_PATH:-/dev/null}:/usr/local/share/iCub/contexts/cameraCalibration/customEyes.ini:rw"
+    - "${APPSAWAY_CALIB_CONTEXT}/icubEyes.ini:/usr/local/share/ICUBcontrib/robots/${YARP_ROBOT_NAME}/icubEyes.ini"
+    - "${ICUB_EYES_PATH:-/dev/null}:/usr/local/share/iCub/contexts/cameraCalibration/customEyes.ini"
   networks:
     - hostnet
 


### PR DESCRIPTION
With this PR I removed the read and write flag from some `.ymls`  because it was not needed. The flag is required only when we want to change the permission of files created by the deployment.