### PR TITLE
Updated appsAway_cleanupCluster.sh to clean the machine when exiting the deployment

### DIFF
--- a/scripts/appsAway_cleanupCluster.sh
+++ b/scripts/appsAway_cleanupCluster.sh
@@ -25,8 +25,20 @@ _BLUE='\033[0;34m'
 _YELLOW='\033[1;33m'
 _PURPLE='\033[1;35m'
 _LGRAY='\033[0;37m'
+_SSH_BIN=$(which ssh || true)
+_SSH_PARAMS="-T"
+_DOCKER_BIN=$(which docker || true)
 _DOCKER_COMPOSE_BIN_CONSOLE=$(which docker-compose || true)
+_DOCKER_ENV_FILE=".env"
 _APPSAWAY_ENV_FILE="appsAway_setEnvironment.local.sh"
+stop_cmd="down"
+if [ "$os" = "Darwin" ]
+then
+  _OS_HOME_DIR=/Users
+else
+  _OS_HOME_DIR=/home
+fi
+
 # ##############################################################################
 print_defs ()
 {
@@ -102,14 +114,37 @@ parse_opt() {
 
 init()
 {
+ log "$0 STARTED"
+ _SSH_BIN=$(which ssh)
+ if [ "${_SSH_BIN}" == "" ]; then
+   exit_err "ssh binary not found"
+ fi
+ _DOCKER_BIN=$(which docker)
+ if [ "${_DOCKER_BIN}" == "" ]; then
+   exit_err "docker binary not found"
+ fi
  if [ "${_DOCKER_COMPOSE_BIN_CONSOLE}" == "" ]; then
    exit_err "docker-compose binary not found in the console node"
  fi
  if [ ! -f "${_APPSAWAY_ENV_FILE}" ]; then
    exit_err "enviroment file ${_APPSAWAY_ENV_FILE} does not exist"
  fi
- source ${_APPSAWAY_ENV_FILE} 
- log "$0 STARTED"
+ source ${_APPSAWAY_ENV_FILE}
+ source ${HOME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/${_DOCKER_ENV_FILE}
+ if [ "$APPSAWAY_ICUBHEADNODE_ADDR" != "" ]; then
+  _DOCKER_COMPOSE_BIN_HEAD=$(ssh $APPSAWAY_ICUBHEADNODE_USERNAME@$APPSAWAY_ICUBHEADNODE_ADDR 'which docker-compose;')
+  echo "Docker compose head path: $_DOCKER_COMPOSE_BIN_HEAD"
+  if [ "${_DOCKER_COMPOSE_BIN_HEAD}" == "" ]; then
+   exit_err "docker-compose binary not found in the head node"
+  fi
+ fi
+ if [ "$APPSAWAY_GUINODE_ADDR" != "" ]; then
+  _DOCKER_COMPOSE_BIN_GUI=$(ssh $APPSAWAY_GUINODE_USERNAME@$APPSAWAY_GUINODE_ADDR 'which docker-compose;')
+  echo "Docker compose gui path: $_DOCKER_COMPOSE_BIN_GUI" 
+  if [ "${_DOCKER_COMPOSE_BIN_GUI}" == "" ]; then
+   exit_err "docker-compose binary not found in the gui node" 
+  fi
+ fi
 }
 
 fini()
@@ -117,21 +152,101 @@ fini()
   log "$0 ENDED "
 }
 
+run_via_ssh()
+{
+  _SSH_CMD_PREFIX_FOR_USER="cd ${_OS_HOME_DIR}/$1/${APPSAWAY_APP_PATH_NOT_CONSOLE}"
+  if [ "$4" != "" ]; then
+    ${_SSH_BIN} ${_SSH_PARAMS} $1@$2 "$_SSH_CMD_PREFIX_FOR_USER ; $3 > $4 2>&1"
+  else
+    ${_SSH_BIN} ${_SSH_PARAMS} $1@$2 "$_SSH_CMD_PREFIX_FOR_USER ; $3"
+  fi
+}
+
+docker_remove_volumes(){
+ssh -T $1@$2<<EOF
+
+
+    dockerVolumes=\$(docker volume ls --format "{{.Name}}")
+    if [ "\$dockerVolumes" != "" ]; then
+        docker volume rm \$dockerVolumes
+        docker volume ls -qf dangling=true | xargs -r docker volume rm #command to make sure the cleanup is complete
+    fi
+
+EOF
+}
+
 clean_up_registry()
 {
-    log "Cleaning up registry created by this deployment..."
     if [[ ${REGISTRY_UP_FLAG} == false ]]
     then
-        log "Removing registry service"
+        log "Cleaning up registry created by this deployment..."
         ${_DOCKER_COMPOSE_BIN_CONSOLE} -f appsAway_registryLaunch.yml down
     else 
         log "No registry has been created by this deployment. No need to remove it."
     fi
 }
 
+stop_deploy()
+{
+  log "executing docker stack stop"
+  ${_DOCKER_BIN} ${_DOCKER_PARAMS} stack rm ${APPSAWAY_STACK_NAME}
+}
+
+docker_clean_up_stack() 
+{
+  for file in ${APPSAWAY_DEPLOY_YAML_FILE_LIST}
+  do
+    log "stopping docker-compose with file ${file} on host $APPSAWAY_CONSOLENODE_ADDR with command ${stop_cmd}"
+    run_via_ssh $APPSAWAY_CONSOLENODE_USERNAME $APPSAWAY_CONSOLENODE_ADDR "if [ -f '$file' ]; then ${_DOCKER_COMPOSE_BIN_CONSOLE} -f ${file} ${stop_cmd}; fi" &
+  done
+  if [ "$APPSAWAY_ICUBHEADNODE_ADDR" != "" ]; then
+    for file in ${APPSAWAY_HEAD_YAML_FILE_LIST}
+    do
+      log "stopping docker-compose with file ${file} on host $APPSAWAY_ICUBHEADNODE_ADDR with command ${stop_cmd}"
+      run_via_ssh $APPSAWAY_ICUBHEADNODE_USERNAME $APPSAWAY_ICUBHEADNODE_ADDR "if [ -f '$file' ]; then ${_DOCKER_COMPOSE_BIN_HEAD} -f ${file} ${stop_cmd}; fi" &
+    done
+  fi
+  if [ "$APPSAWAY_GUINODE_ADDR" != "" ]; then
+    for file in ${APPSAWAY_GUI_YAML_FILE_LIST}
+    do
+      log "stopping docker-compose with file ${file} on host $APPSAWAY_GUINODE_ADDR with command ${stop_cmd}"
+      run_via_ssh $APPSAWAY_GUINODE_USERNAME $APPSAWAY_GUINODE_ADDR "if [ -f '$file' ]; then ${_DOCKER_COMPOSE_BIN_GUI} -f ${file} ${stop_cmd}; fi" &
+    done
+  elif [ "$APPSAWAY_GUINODE_ADDR" == "" ] && [ "$APPSAWAY_CONSOLENODE_ADDR" != "" ]; then
+    for file in ${APPSAWAY_GUI_YAML_FILE_LIST}
+    do
+      log "stopping docker-compose with file ${file} on host $APPSAWAY_CONSOLENODE_ADDR with command ${stop_cmd}"
+      run_via_ssh $APPSAWAY_CONSOLENODE_USERNAME $APPSAWAY_CONSOLENODE_ADDR "if [ -f '$file' ]; then ${_DOCKER_COMPOSE_BIN_CONSOLE} -f ${file} ${stop_cmd}; fi" &
+    done
+  fi
+  wait
+  nodes_addr_list=(${APPSAWAY_NODES_ADDR_LIST})
+  nodes_username_list=(${APPSAWAY_NODES_USERNAME_LIST})
+  for index in "${!nodes_addr_list[@]}"
+  do
+    log "Removing all the stopped containers in node ${nodes_addr_list[$index]}..."
+    run_via_ssh ${nodes_username_list[$index]} ${nodes_addr_list[$index]} "docker container prune --force" &
+  done
+  wait
+  for index in "${!nodes_addr_list[@]}"
+  do
+    log "Removing all volumes not referenced by any containers (i.e. dangling volumes) in node ${nodes_addr_list[$index]}..."
+    docker_remove_volumes ${nodes_username_list[$index]} ${nodes_addr_list[$index]}
+    if [ ${nodes_addr_list[$index]} != "$APPSAWAY_CONSOLENODE_ADDR" ]; then
+      log "Leaving the swarm in node ${nodes_addr_list[$index]}..."
+      run_via_ssh ${nodes_username_list[$index]} ${nodes_addr_list[$index]} "docker swarm leave --force |& grep -v Error" 
+    fi
+  done
+  log "Killing the swarm..."
+  docker swarm leave --force |& grep -v Error
+}
+
 main()
 { 
   clean_up_registry
+  source appsAway_setEnvironment.local.sh
+  stop_deploy
+  docker_clean_up_stack
 }
 
 parse_opt "$@"

--- a/scripts/appsAway_setupRegistry.sh
+++ b/scripts/appsAway_setupRegistry.sh
@@ -121,7 +121,7 @@ fini()
 
 
 check_registry() 
-{
+{ 
   REGISTRY_UP_FLAG=true
   container_id_list=($(${_DOCKER_BIN} container ls --format "table {{.ID}}"))
   container_id_list=(${container_id_list[@]:2})
@@ -132,11 +132,14 @@ check_registry()
   else
     for id in ${container_id_list[@]}
     do
-      port_content="$(${_DOCKER_BIN} inspect $id | grep "5000/tcp")"
+      port_content=$(echo "$(${_DOCKER_BIN} inspect $id | grep "5000/tcp")")
+
       if [ "$port_content" == "" ]
       then
         REGISTRY_UP_FLAG=false
       else
+        REGISTRY_UP_FLAG=true      
+        echo "export REGISTRY_UP_FLAG="$REGISTRY_UP_FLAG >> ${HOME}/teamcode/appsAway/scripts/${_APPSAWAY_ENV_FILE}
         exit_err "A container is already running on port 5000"
       fi
     done

--- a/scripts/appsAway_stopApp.sh
+++ b/scripts/appsAway_stopApp.sh
@@ -311,8 +311,8 @@ stop_hardware_steps_via_ssh()
 stop_deploy()
 {
 
-  log "executing docker stack deploy"
-  export $(cat .env)
+  log "executing docker stack stop"
+  #export $(cat .env)
   #cd $APPSAWAY_APP_PATH
   #for _file2deploy in ${APPSAWAY_DEPLOY_YAML_FILE_LIST}
   #do


### PR DESCRIPTION
With this PR we want to update `appsAway_cleanupCluster.sh` in order to properly clean the system when the deployment exists with an error. 
In particular, we added different functions, each of which performs a specific task:
- remove a registry created by the deployment;
- remove all the services and containers launched by the deployment;
- remove all the volumes created by the deployment;
- remove all the nodes from the swarm and kill the swarm manager.

We structured the script in order to handle different cleaning options by passing them as input to the script itself. On the basis of the above, the possible options are:
- "registry"
- "stack"
- "volumes"
- "swarm"
- without passing any options we clean up everything (i.e. registry, stack, volumes, swarm)

The `appsAway_cleanupCluster.sh` is executed in different points of the `demoName_setup.sh` and, depending on the step where we are, we pass a different input to the script.

While implementing these changes, we fixed also other small issues:
- fixed the command that checks if there is a container already running on port `5000`
- included new `GUI_XAUTHORITY` variable for machines with different `UIDs`
- fixed the `GUI_DISPLAY` command that was not retrieving any running processes