### PR TITLE
Speeded up pipeline by making local registry conditional

### DIFF
--- a/scripts/appsAway_setupCluster.sh
+++ b/scripts/appsAway_setupCluster.sh
@@ -360,7 +360,7 @@ find_docker_images()
       current_image=${APPSAWAY_IMAGES_LIST[$index]}:${APPSAWAY_TAGS_LIST[$index]}
     fi
     log "Checking if image $current_image exists on DockerHub..."
-    manifest_found=$( ${_DOCKER_BIN} manifest inspect $current_image || true )
+    manifest_found=$( ${_DOCKER_BIN} manifest inspect $current_image 2> /dev/null || true )
     if [[ $manifest_found == "" ]]; then
       log "Manifest not found"
       pull_result+=(1)
@@ -429,6 +429,8 @@ find_docker_images()
         log "Image not found locally"
         exit_err "Image $current_image was not found on DockerHub nor locally. Please be sure that the name is correct."
       fi
+    else
+      APPSAWAY_REGISTRY_IMAGES="$APPSAWAY_REGISTRY_IMAGES ${APPSAWAY_IMAGES_LIST[$index]}" 
     fi
   done
   wait

--- a/scripts/appsAway_setupCluster.sh
+++ b/scripts/appsAway_setupCluster.sh
@@ -140,6 +140,7 @@ init()
  if [ "$os" = "Darwin" ]
  then
   _ALL_LOCAL_IP_ADDRESSES=$(arp -a | awk -F'[()]' '{print $2}')
+# ' This brings color back to visual code :D
  else
   _ALL_LOCAL_IP_ADDRESSES=$(hostname --all-ip-address)
   _ALL_LOCAL_IP_ADDRESSES+=$(hostname --all-fqdns)
@@ -403,10 +404,10 @@ find_docker_images()
     else
       current_image=${APPSAWAY_IMAGES_LIST[$index]}:${APPSAWAY_TAGS_LIST[$index]}
     fi 
-    if (( ${pull_result[$index]} == 0 )); then
-      log "Pulling image $current_image, this might take a few minutes..."
-      ${_DOCKER_BIN} pull --quiet $current_image &> /dev/null || true &
-    fi
+#    if (( ${pull_result[$index]} == 0 )); then
+#      log "Pulling image $current_image, this might take a few minutes..."
+#      ${_DOCKER_BIN} pull --quiet $current_image &> /dev/null || true &
+#    fi
   done
   for index in "${!APPSAWAY_IMAGES_LIST[@]}"
   do

--- a/scripts/appsAway_setupRegistry.sh
+++ b/scripts/appsAway_setupRegistry.sh
@@ -134,7 +134,6 @@ check_registry()
     for id in ${container_id_list[@]}
     do
       port_content=$(echo "$(${_DOCKER_BIN} inspect $id | grep "5000/tcp")")
-
       if [ "$port_content" == "" ]
       then
         REGISTRY_UP_FLAG=false
@@ -153,6 +152,7 @@ check_registry()
 
   REQUIRES_REGISTRY=false
   IS_THERE_REMOTE_IMAGE=false
+  IS_THERE_LOCAL_IMAGE=false
   APPSAWAY_MANIFEST_FOUND=()
   for index in "${!APPSAWAY_IMAGES_LIST[@]}"
   do
@@ -167,6 +167,7 @@ check_registry()
     if [[ $manifest_found == "" ]]; then
       # local image
       log "Manifest not found"
+      IS_THERE_LOCAL_IMAGE=true
       APPSAWAY_MANIFEST_FOUND+=(0)
     else
       # remote image
@@ -176,9 +177,9 @@ check_registry()
     fi
   done  
  
-  echo "manifest found: ${IS_THERE_REMOTE_IMAGE}"
+  # echo "manifest found: ${IS_THERE_REMOTE_IMAGE}"
   echo "nodes name list size: ${#APPSAWAY_NODES_NAME[@]}"
-  if [[ ${IS_THERE_REMOTE_IMAGE} == false && ${#APPSAWAY_NODES_NAME[@]} > 1 ]]
+  if [[ ${IS_THERE_LOCAL_IMAGE} == true && ${#APPSAWAY_NODES_NAME[@]} > 1 ]]
   then
     echo "requires registry true"
     REQUIRES_REGISTRY=true

--- a/scripts/appsAway_startApp.sh
+++ b/scripts/appsAway_startApp.sh
@@ -355,7 +355,7 @@ run_hardware_steps_via_ssh()
       run_via_ssh $APPSAWAY_CONSOLENODE_USERNAME $APPSAWAY_CONSOLENODE_ADDR "export APPSAWAY_OPTIONS=${APPSAWAY_OPTIONS} ; export DISPLAY=${mydisplay} ; export XAUTHORITY=${myXauth};  export _YAML_VOLUMES_HOST=\"${_YAML_VOLUMES_HOST}\" ; export APPSAWAY_APP_PATH_NOT_CONSOLE=${APPSAWAY_APP_PATH_NOT_CONSOLE} ; ${_OS_HOME_DIR}/${APPSAWAY_CONSOLENODE_USERNAME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/appsAway_getVolumesFileList.sh ; if [ -f '$file' ]; then ${_DOCKER_PULL} ; ${_DOCKER_COMPOSE_BIN_CONSOLE} -f ${file} up --detach; fi"
     done
   fi ) &
-  val1=$(( $val1 + 5 ))
+  val1=$(( $val1 + 10 ))
   echo $val1 >| ${HOME}/teamcode/appsAway/scripts/PIPE
 }
 

--- a/scripts/appsAway_startApp.sh
+++ b/scripts/appsAway_startApp.sh
@@ -309,7 +309,7 @@ run_hardware_steps_via_ssh()
       # We only need to pull if there is a registry to pull from
       if [[ ${MUST_PULL_IMAGES} == true ]]
       then
-        _DOCKER_PULL="${_DOCKER_COMPOSE_BIN_HEAD} -f ${file} pull 2> dev/null"
+        _DOCKER_PULL="${_DOCKER_COMPOSE_BIN_HEAD} -f ${file} pull"
       else
         _DOCKER_PULL="true"
       fi     
@@ -327,8 +327,15 @@ run_hardware_steps_via_ssh()
       scp_to_node ${_CWD}/appsAway_containerPermissions.sh $APPSAWAY_GUINODE_USERNAME $APPSAWAY_GUINODE_ADDR $APPSAWAY_APP_PATH_NOT_CONSOLE
       scp_to_node ${_CWD}/appsAway_changeNewFilesPermissions.sh $APPSAWAY_GUINODE_USERNAME $APPSAWAY_GUINODE_ADDR $APPSAWAY_APP_PATH_NOT_CONSOLE
       scp_to_node ${_CWD}/appsAway_getVolumesFileList.sh $APPSAWAY_GUINODE_USERNAME $APPSAWAY_GUINODE_ADDR $APPSAWAY_APP_PATH_NOT_CONSOLE
-      log "we are using the following variables: DISPLAY=${GUI_DISPLAY}; XAUTHORITY=${GUI_XAUTHORITY}"
-      run_via_ssh $APPSAWAY_GUINODE_USERNAME $APPSAWAY_GUINODE_ADDR "export APPSAWAY_OPTIONS=${APPSAWAY_OPTIONS} ; export ${GUI_DISPLAY} ; export XAUTHORITY=${GUI_XAUTHORITY}; export _YAML_VOLUMES_HOST=\"${_YAML_VOLUMES_HOST}\" ; export APPSAWAY_APP_PATH_NOT_CONSOLE=${APPSAWAY_APP_PATH_NOT_CONSOLE} ; ${_OS_HOME_DIR}/${APPSAWAY_GUINODE_USERNAME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/appsAway_getVolumesFileList.sh ; if [ -f '$file' ]; then ${_DOCKER_COMPOSE_BIN_GUI} -f ${file} pull; ${_DOCKER_COMPOSE_BIN_GUI} -f ${file} up --detach; fi"
+      log "we are using the following variables: DISPLAY=${GUI_DISPLAY}; XAUTHORITY=${GUI_XAUTHORITY}"     
+      # We only need to pull if there is a registry to pull from
+      if [[ ${MUST_PULL_IMAGES} == true ]]
+      then
+        _DOCKER_PULL="${_DOCKER_COMPOSE_BIN_GUI} -f ${file} pull"
+      else
+        _DOCKER_PULL="true"
+      fi  
+      run_via_ssh $APPSAWAY_GUINODE_USERNAME $APPSAWAY_GUINODE_ADDR "export APPSAWAY_OPTIONS=${APPSAWAY_OPTIONS} ; export ${GUI_DISPLAY} ; export XAUTHORITY=${GUI_XAUTHORITY}; export _YAML_VOLUMES_HOST=\"${_YAML_VOLUMES_HOST}\" ; export APPSAWAY_APP_PATH_NOT_CONSOLE=${APPSAWAY_APP_PATH_NOT_CONSOLE} ; ${_OS_HOME_DIR}/${APPSAWAY_GUINODE_USERNAME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/appsAway_getVolumesFileList.sh ; if [ -f '$file' ]; then ${_DOCKER_PULL}; ${_DOCKER_COMPOSE_BIN_GUI} -f ${file} up --detach; fi"
     done
   elif [ "$APPSAWAY_GUINODE_ADDR" == "" ] && [ "$APPSAWAY_CONSOLENODE_ADDR" != "" ]; then
     for file in ${APPSAWAY_GUI_YAML_FILE_LIST}
@@ -341,7 +348,7 @@ run_hardware_steps_via_ssh()
       # We only need to pull if there is a registry to pull from
       if [[ ${MUST_PULL_IMAGES} == true ]]
       then
-        _DOCKER_PULL="${_DOCKER_COMPOSE_BIN_CONSOLE} -f ${file} pull 2> dev/null"
+        _DOCKER_PULL="${_DOCKER_COMPOSE_BIN_CONSOLE} -f ${file} pull"
       else
         _DOCKER_PULL="true"
       fi  

--- a/scripts/appsAway_startApp.sh
+++ b/scripts/appsAway_startApp.sh
@@ -305,8 +305,15 @@ run_hardware_steps_via_ssh()
       #run_via_ssh_nowait $APPSAWAY_ICUBHEADNODE_ADDR "${_DOCKER_COMPOSE_BIN} -f ${file} up" "log.txt"
       scp_to_node ${_CWD}/appsAway_containerPermissions.sh $APPSAWAY_ICUBHEADNODE_USERNAME $APPSAWAY_ICUBHEADNODE_ADDR $APPSAWAY_APP_PATH_NOT_CONSOLE
       scp_to_node ${_CWD}/appsAway_changeNewFilesPermissions.sh $APPSAWAY_ICUBHEADNODE_USERNAME $APPSAWAY_ICUBHEADNODE_ADDR $APPSAWAY_APP_PATH_NOT_CONSOLE      
-      scp_to_node ${_CWD}/appsAway_getVolumesFileList.sh $APPSAWAY_ICUBHEADNODE_USERNAME $APPSAWAY_ICUBHEADNODE_ADDR $APPSAWAY_APP_PATH_NOT_CONSOLE      
-      run_via_ssh $APPSAWAY_ICUBHEADNODE_USERNAME $APPSAWAY_ICUBHEADNODE_ADDR "export APPSAWAY_OPTIONS=${APPSAWAY_OPTIONS} ; export _YAML_VOLUMES_HOST=\"${_YAML_VOLUMES_HOST}\" ; export APPSAWAY_APP_PATH_NOT_CONSOLE=${APPSAWAY_APP_PATH_NOT_CONSOLE} ; ${_OS_HOME_DIR}/${APPSAWAY_CONSOLENODE_USERNAME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/appsAway_getVolumesFileList.sh ; ${_DOCKER_COMPOSE_BIN_HEAD} -f ${file} pull; ${_DOCKER_COMPOSE_BIN_HEAD} -f ${file} up --detach"
+      scp_to_node ${_CWD}/appsAway_getVolumesFileList.sh $APPSAWAY_ICUBHEADNODE_USERNAME $APPSAWAY_ICUBHEADNODE_ADDR $APPSAWAY_APP_PATH_NOT_CONSOLE 
+      # We only need to pull if there is a registry to pull from
+      if [[ ${MUST_PULL_IMAGES} == true ]]
+      then
+        _DOCKER_PULL="${_DOCKER_COMPOSE_BIN_HEAD} -f ${file} pull 2> dev/null"
+      else
+        _DOCKER_PULL="true"
+      fi     
+      run_via_ssh $APPSAWAY_ICUBHEADNODE_USERNAME $APPSAWAY_ICUBHEADNODE_ADDR "export APPSAWAY_OPTIONS=${APPSAWAY_OPTIONS} ; export _YAML_VOLUMES_HOST=\"${_YAML_VOLUMES_HOST}\" ; export APPSAWAY_APP_PATH_NOT_CONSOLE=${APPSAWAY_APP_PATH_NOT_CONSOLE} ; ${_OS_HOME_DIR}/${APPSAWAY_CONSOLENODE_USERNAME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/appsAway_getVolumesFileList.sh ; ${_DOCKER_PULL} ; ${_DOCKER_COMPOSE_BIN_HEAD} -f ${file} up --detach"
     done
   fi ) &
   val1=$(( $val1 + 5 ))
@@ -331,7 +338,14 @@ run_hardware_steps_via_ssh()
       scp_to_node ${_CWD}/appsAway_containerPermissions.sh $APPSAWAY_CONSOLENODE_USERNAME $APPSAWAY_CONSOLENODE_ADDR $APPSAWAY_APP_PATH_NOT_CONSOLE
       scp_to_node ${_CWD}/appsAway_changeNewFilesPermissions.sh $APPSAWAY_CONSOLENODE_USERNAME $APPSAWAY_CONSOLENODE_ADDR $APPSAWAY_APP_PATH_NOT_CONSOLE
       scp_to_node ${_CWD}/appsAway_getVolumesFileList.sh $APPSAWAY_CONSOLENODE_USERNAME $APPSAWAY_CONSOLENODE_ADDR $APPSAWAY_APP_PATH_NOT_CONSOLE       
-      run_via_ssh $APPSAWAY_CONSOLENODE_USERNAME $APPSAWAY_CONSOLENODE_ADDR "export APPSAWAY_OPTIONS=${APPSAWAY_OPTIONS} ; export DISPLAY=${mydisplay} ; export XAUTHORITY=${myXauth};  export _YAML_VOLUMES_HOST=\"${_YAML_VOLUMES_HOST}\" ; export APPSAWAY_APP_PATH_NOT_CONSOLE=${APPSAWAY_APP_PATH_NOT_CONSOLE} ; ${_OS_HOME_DIR}/${APPSAWAY_CONSOLENODE_USERNAME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/appsAway_getVolumesFileList.sh ; if [ -f '$file' ]; then ${_DOCKER_COMPOSE_BIN_CONSOLE} -f ${file} pull; ${_DOCKER_COMPOSE_BIN_CONSOLE} -f ${file} up --detach; fi"
+      # We only need to pull if there is a registry to pull from
+      if [[ ${MUST_PULL_IMAGES} == true ]]
+      then
+        _DOCKER_PULL="${_DOCKER_COMPOSE_BIN_CONSOLE} -f ${file} pull 2> dev/null"
+      else
+        _DOCKER_PULL="true"
+      fi  
+      run_via_ssh $APPSAWAY_CONSOLENODE_USERNAME $APPSAWAY_CONSOLENODE_ADDR "export APPSAWAY_OPTIONS=${APPSAWAY_OPTIONS} ; export DISPLAY=${mydisplay} ; export XAUTHORITY=${myXauth};  export _YAML_VOLUMES_HOST=\"${_YAML_VOLUMES_HOST}\" ; export APPSAWAY_APP_PATH_NOT_CONSOLE=${APPSAWAY_APP_PATH_NOT_CONSOLE} ; ${_OS_HOME_DIR}/${APPSAWAY_CONSOLENODE_USERNAME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/appsAway_getVolumesFileList.sh ; if [ -f '$file' ]; then ${_DOCKER_PULL} ; ${_DOCKER_COMPOSE_BIN_CONSOLE} -f ${file} up --detach; fi"
     done
   fi ) &
   val1=$(( $val1 + 5 ))

--- a/scripts/appsAway_startApp.sh
+++ b/scripts/appsAway_startApp.sh
@@ -237,11 +237,11 @@ run_deploy()
   
   for _file2deploy in ${APPSAWAY_DEPLOY_YAML_FILE_LIST}
   do       
-    log "downloading the image: ${_DOCKER_COMPOSE_BIN_CONSOLE} -f ${_file2deploy} up" # pull "
-    ${_DOCKER_COMPOSE_BIN_CONSOLE} -f ${_file2deploy} pull
-    log "pushing image into service registry for distribution in swarm"
-    ${_DOCKER_COMPOSE_BIN_CONSOLE} -f ${_file2deploy} push
-    log "Image from ${_file2deploy} successfully pushed"
+    #log "downloading the image: ${_DOCKER_COMPOSE_BIN_CONSOLE} -f ${_file2deploy} up" # pull "
+    #${_DOCKER_COMPOSE_BIN_CONSOLE} -f ${_file2deploy} pull
+    #log "pushing image into service registry for distribution in swarm"
+    #${_DOCKER_COMPOSE_BIN_CONSOLE} -f ${_file2deploy} push
+    #log "Image from ${_file2deploy} successfully pushed"
     val1=$(( $val1 + 10 ))
     echo $val1 >| ${HOME}/teamcode/appsAway/scripts/PIPE
     ${_DOCKER_BIN} ${_DOCKER_PARAMS} stack deploy -c ${_file2deploy} ${APPSAWAY_STACK_NAME}
@@ -270,6 +270,7 @@ scp_to_node()
   ip_to_receive=$3
   path_to_receive=$4
   full_path_to_receive=${_OS_HOME_DIR}/${username_to_receive}/${path_to_receive}
+  # TODO: this only works in ubuntu, we should check how to do this in other OS
   ${_SCP_BIN} ${_SCP_PARAMS_DIR} ${file_to_send} ${username_to_receive}@${ip_to_receive}:${full_path_to_receive}/
 }
 
@@ -297,7 +298,7 @@ run_hardware_steps_via_ssh()
     scp_to_node ${_CWD}/appsAway_getVolumesFileList.sh $APPSAWAY_CONSOLENODE_USERNAME $APPSAWAY_CONSOLENODE_ADDR $APPSAWAY_APP_PATH_NOT_CONSOLE       
     run_via_ssh $APPSAWAY_CONSOLENODE_USERNAME $APPSAWAY_CONSOLENODE_ADDR "export APPSAWAY_OPTIONS=${APPSAWAY_OPTIONS} ; export _YAML_VOLUMES_HOST=\"${_YAML_VOLUMES_HOST}\" ; export APPSAWAY_APP_PATH_NOT_CONSOLE=${APPSAWAY_APP_PATH_NOT_CONSOLE} ; ${_OS_HOME_DIR}/${APPSAWAY_CONSOLENODE_USERNAME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/appsAway_getVolumesFileList.sh"  
  fi
- if [ "$APPSAWAY_ICUBHEADNODE_ADDR" != "" ]; then
+ ( if [ "$APPSAWAY_ICUBHEADNODE_ADDR" != "" ]; then
     for file in ${APPSAWAY_HEAD_YAML_FILE_LIST}
     do
       log "running ${_DOCKER_COMPOSE_BIN_HEAD} with file ${_OS_HOME_DIR}/${APPSAWAY_ICUBHEADNODE_USERNAME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/${file} on host $APPSAWAY_ICUBHEADNODE_ADDR"
@@ -307,11 +308,11 @@ run_hardware_steps_via_ssh()
       scp_to_node ${_CWD}/appsAway_getVolumesFileList.sh $APPSAWAY_ICUBHEADNODE_USERNAME $APPSAWAY_ICUBHEADNODE_ADDR $APPSAWAY_APP_PATH_NOT_CONSOLE      
       run_via_ssh $APPSAWAY_ICUBHEADNODE_USERNAME $APPSAWAY_ICUBHEADNODE_ADDR "export APPSAWAY_OPTIONS=${APPSAWAY_OPTIONS} ; export _YAML_VOLUMES_HOST=\"${_YAML_VOLUMES_HOST}\" ; export APPSAWAY_APP_PATH_NOT_CONSOLE=${APPSAWAY_APP_PATH_NOT_CONSOLE} ; ${_OS_HOME_DIR}/${APPSAWAY_CONSOLENODE_USERNAME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/appsAway_getVolumesFileList.sh ; ${_DOCKER_COMPOSE_BIN_HEAD} -f ${file} pull; ${_DOCKER_COMPOSE_BIN_HEAD} -f ${file} up --detach"
     done
-    val1=$(( $val1 + 5 ))
-    echo $val1 >| ${HOME}/teamcode/appsAway/scripts/PIPE
-  fi
+  fi ) &
+  val1=$(( $val1 + 5 ))
+  echo $val1 >| ${HOME}/teamcode/appsAway/scripts/PIPE
   #sleep 3
-  if [ "$APPSAWAY_GUINODE_ADDR" != "" ]; then
+  ( if [ "$APPSAWAY_GUINODE_ADDR" != "" ]; then
     for file in ${APPSAWAY_GUI_YAML_FILE_LIST}
     do
       log "running ${_DOCKER_COMPOSE_BIN_GUI} with file ${_OS_HOME_DIR}/${APPSAWAY_GUINODE_USERNAME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/${file} on host $APPSAWAY_GUINODE_ADDR"
@@ -322,8 +323,6 @@ run_hardware_steps_via_ssh()
       log "we are using the following variables: DISPLAY=${GUI_DISPLAY}; XAUTHORITY=${GUI_XAUTHORITY}"
       run_via_ssh $APPSAWAY_GUINODE_USERNAME $APPSAWAY_GUINODE_ADDR "export APPSAWAY_OPTIONS=${APPSAWAY_OPTIONS} ; export ${GUI_DISPLAY} ; export XAUTHORITY=${GUI_XAUTHORITY}; export _YAML_VOLUMES_HOST=\"${_YAML_VOLUMES_HOST}\" ; export APPSAWAY_APP_PATH_NOT_CONSOLE=${APPSAWAY_APP_PATH_NOT_CONSOLE} ; ${_OS_HOME_DIR}/${APPSAWAY_GUINODE_USERNAME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/appsAway_getVolumesFileList.sh ; if [ -f '$file' ]; then ${_DOCKER_COMPOSE_BIN_GUI} -f ${file} pull; ${_DOCKER_COMPOSE_BIN_GUI} -f ${file} up --detach; fi"
     done
-    val1=$(( $val1 + 5 ))
-    echo $val1 >| ${HOME}/teamcode/appsAway/scripts/PIPE
   elif [ "$APPSAWAY_GUINODE_ADDR" == "" ] && [ "$APPSAWAY_CONSOLENODE_ADDR" != "" ]; then
     for file in ${APPSAWAY_GUI_YAML_FILE_LIST}
     do
@@ -334,9 +333,9 @@ run_hardware_steps_via_ssh()
       scp_to_node ${_CWD}/appsAway_getVolumesFileList.sh $APPSAWAY_CONSOLENODE_USERNAME $APPSAWAY_CONSOLENODE_ADDR $APPSAWAY_APP_PATH_NOT_CONSOLE       
       run_via_ssh $APPSAWAY_CONSOLENODE_USERNAME $APPSAWAY_CONSOLENODE_ADDR "export APPSAWAY_OPTIONS=${APPSAWAY_OPTIONS} ; export DISPLAY=${mydisplay} ; export XAUTHORITY=${myXauth};  export _YAML_VOLUMES_HOST=\"${_YAML_VOLUMES_HOST}\" ; export APPSAWAY_APP_PATH_NOT_CONSOLE=${APPSAWAY_APP_PATH_NOT_CONSOLE} ; ${_OS_HOME_DIR}/${APPSAWAY_CONSOLENODE_USERNAME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/appsAway_getVolumesFileList.sh ; if [ -f '$file' ]; then ${_DOCKER_COMPOSE_BIN_CONSOLE} -f ${file} pull; ${_DOCKER_COMPOSE_BIN_CONSOLE} -f ${file} up --detach; fi"
     done
-    val1=$(( $val1 + 5 ))
-    echo $val1 >| ${HOME}/teamcode/appsAway/scripts/PIPE
-  fi
+  fi ) &
+  val1=$(( $val1 + 5 ))
+  echo $val1 >| ${HOME}/teamcode/appsAway/scripts/PIPE
 }
 
 stop_hardware_steps_via_ssh()
@@ -382,10 +381,11 @@ main()
   is_this_node_swarm_master
   val1=$(( 30 ))
   echo $val1 >| ${HOME}/teamcode/appsAway/scripts/PIPE
-  run_deploy
+  run_deploy &
   val1=$(( 70 ))
   echo $val1 >| ${HOME}/teamcode/appsAway/scripts/PIPE
   run_hardware_steps_via_ssh
+  wait
   val1=$(( 90 ))
   echo $val1 >| ${HOME}/teamcode/appsAway/scripts/PIPE
 #  stop_hardware_steps_via_ssh


### PR DESCRIPTION
This PR increases the speed of the deployment by removing the local registry when it is not needed. In the case where there is one node in the cluster, or when all images are found in Dockerhub, the local registry is avoided. Thus saving the time it takes to push into it and pull again.

Notable changes:

- In `appsAway_setupRegistry.sh` we inspect the manifest of the image to know which images are local and which remote. If at least one image is local, and there is more than one node in the cluster, the registry is created.

- Image names are only retagged with `{CONSOLE_IP}:5000/image-name` if there is at least one local image and the number of nodes is greater than one.

- Added a new exported variable `MUST_PULL` to identify whether or not the registry has been created or if there is at least one image that needs to be pulled from Dockerhub

- Updated the `appsAway_startApp.sh` script to use the `MUST_PULL` variable to check if the `docker-compose pull` command needs to be run.