### PR TITLE
Fixed issues when launching yarpserver through the deployment

### DIFF
--- a/.ci/docker-compose.yml
+++ b/.ci/docker-compose.yml
@@ -9,7 +9,7 @@ x-yarp-base: &yarp-base
 services:
     yarp-server:
       <<: *yarp-base
-      command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --write; fi"
+      command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --read; fi"
 
     listener:
       <<: *yarp-base

--- a/.ci/docker-yarpbasic.yml
+++ b/.ci/docker-yarpbasic.yml
@@ -17,7 +17,7 @@ x-yarp-base: &yarp-base
 services:
     yarp-server:
       <<: *yarp-base
-      command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --write; fi"
+      command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --read; fi"
 
     yarp-dev:
       <<: *yarp-base

--- a/.ci/docker-yarpgazebo.yml
+++ b/.ci/docker-yarpgazebo.yml
@@ -15,7 +15,7 @@ x-yarp-base: &yarp-base
 services:
     yarp-server:
       <<: *yarp-base
-      command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --write; fi"
+      command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --read; fi"
 
     yarp-gazebo:
       <<: *yarp-base

--- a/demos/cameraTiltCalib/main.yml
+++ b/demos/cameraTiltCalib/main.yml
@@ -23,7 +23,7 @@ services:
         constraints: [node.role == manager]
       restart_policy:
         condition: on-failure
-    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --write; fi"
+    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --read; fi"
 
 
 

--- a/demos/demoTemplate/main.yml.template
+++ b/demos/demoTemplate/main.yml.template
@@ -28,7 +28,7 @@ services:
     deploy:
       placement:
         constraints: [node.role == manager]
-    command: yarpserver --write
+    command: yarpserver --read
 
 
 #################################### ADD YOUR SERVICES HERE #####################################

--- a/demos/faceAndPoseDetection/main.yml
+++ b/demos/faceAndPoseDetection/main.yml
@@ -59,7 +59,7 @@ services:
         constraints: [node.role == manager]
       restart_policy:
         condition: on-failure
-    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --write; fi"
+    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --read; fi"
 
 #--------------------------------------- Connects ----------------------------------------------
 

--- a/demos/funnyThingsApp/main.yml
+++ b/demos/funnyThingsApp/main.yml
@@ -21,7 +21,7 @@ services:
     deploy:
       placement:
         constraints: [node.role == manager]
-    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --write; fi"
+    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --read; fi"
     
   iCubBlinker_0:
     <<: *yarp-base

--- a/demos/googleDialog/composeGui.yml
+++ b/demos/googleDialog/composeGui.yml
@@ -37,7 +37,7 @@ services:
     <<: *yarp-base
     devices: 
       - "/dev/snd:/dev/snd"
-    command: sh -c "yarp wait /root; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --rate 16000 --samples 16000"
+    command: sh -c "if [ -f "/root/.config/yarp/yarp_namespace.conf" ]; then yarp wait $$(echo $$(cat /root/.config/yarp/yarp_namespace.conf)); else yarp wait /root; fi; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --rate 16000 --samples 16000"
 
   yDemoGoogleSynthesis:
     <<: *yarp-base

--- a/demos/googleDialog/main.yml
+++ b/demos/googleDialog/main.yml
@@ -33,7 +33,7 @@ services:
         constraints: [node.role == manager]
       restart_policy:
         condition: on-failure
-    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --write; fi"
+    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --read; fi"
   
 #------------------------------------------------------------------------------------------------
   yDemoGoogleSpeech:

--- a/demos/googleSpeechApp/composeGui.yml
+++ b/demos/googleSpeechApp/composeGui.yml
@@ -37,7 +37,7 @@ services:
     <<: *yarp-base
     devices: 
       - "/dev/snd:/dev/snd"
-    command: sh -c "if [ ${GOOGLE_INPUT} = 'True' ]; then yarp wait /root; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --rate 16000 --samples 16000; fi;"
+    command: sh -c "if [ ${GOOGLE_INPUT} = 'True' ]; then if [ -f "/root/.config/yarp/yarp_namespace.conf" ]; then yarp wait $$(echo $$(cat /root/.config/yarp/yarp_namespace.conf)); else yarp wait /root; fi; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --rate 16000 --samples 16000; fi;"
 
   yDemoGoogleSynthesis:
     <<: *yarp-base

--- a/demos/googleSpeechApp/main.yml
+++ b/demos/googleSpeechApp/main.yml
@@ -35,7 +35,7 @@ services:
         constraints: [node.role == manager]
       restart_policy:
         condition: on-failure
-    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --write; fi"
+    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --read; fi"
   
 #------------------------------------------------------------------------------------------------
   yDemoGoogleSpeech:

--- a/demos/googleSpeechProcessing/composeGui.yml
+++ b/demos/googleSpeechProcessing/composeGui.yml
@@ -31,7 +31,7 @@ services:
     <<: *yarp-base
     devices: 
       - "/dev/snd:/dev/snd"
-    command: sh -c "yarp wait /root; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --rate 16000 --samples 16000"
+    command: sh -c "if [ -f "/root/.config/yarp/yarp_namespace.conf" ]; then yarp wait $$(echo $$(cat /root/.config/yarp/yarp_namespace.conf)); else yarp wait /root; fi; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --rate 16000 --samples 16000"
   
   yconnect_audio:
     <<: *yarp-base

--- a/demos/googleSpeechProcessing/main.yml
+++ b/demos/googleSpeechProcessing/main.yml
@@ -31,7 +31,7 @@ services:
         constraints: [node.role == manager]
       restart_policy:
         condition: on-failure
-    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --write; fi"
+    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --read; fi"
   
 #------------------------------------------------------------------------------------------------
   yDemoGoogleSpeech:

--- a/demos/googleVisionAI/main.yml
+++ b/demos/googleVisionAI/main.yml
@@ -24,10 +24,10 @@ services:
         constraints: [node.role == manager]
       restart_policy:
         condition: on-failure
-    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --write; fi"
+    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --read; fi"
 
 
-    #command: sh -c "_YARP_GOT=$$( yarp where | grep 'is available at ip' > /dev/null ); echo '${_YARP_GOT}'; if [ -z '${_YARP_GOT}' ]; then yarpserver --write; fi"
+    #command: sh -c "_YARP_GOT=$$( yarp where | grep 'is available at ip' > /dev/null ); echo '${_YARP_GOT}'; if [ -z '${_YARP_GOT}' ]; then yarpserver --read; fi"
 #------------------------------------------------------------------------------------------------
   yDemoGoogleVisionAI:
     <<: *yarp-base

--- a/demos/graspTheBall/main.yml
+++ b/demos/graspTheBall/main.yml
@@ -41,7 +41,7 @@ services:
         constraints: [node.role == manager]
       restart_policy:
         condition: on-failure
-    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --write; fi"
+    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --read; fi"
 
   yCartesianSolver_r:
     <<: *yarp-base

--- a/demos/graspTheBallGazebo/main.yml
+++ b/demos/graspTheBallGazebo/main.yml
@@ -32,7 +32,7 @@ services:
         constraints: [node.role == manager]
       restart_policy:
         condition: on-failure
-    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --write; fi"
+    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --read; fi"
 
   yRobotInterface:
     <<: *yarp-base

--- a/demos/iCubGazeboGrasping/main.yml
+++ b/demos/iCubGazeboGrasping/main.yml
@@ -24,7 +24,7 @@ services:
         constraints: [node.role == manager]
       restart_policy:
         condition: on-failure
-    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --write; fi"
+    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --read; fi"
 
   yStartDemo:
     <<: *yarp-base

--- a/demos/robotBaseStartup/main.yml
+++ b/demos/robotBaseStartup/main.yml
@@ -24,7 +24,7 @@ services:
         constraints: [node.role == manager]
       restart_policy:
         condition: on-failure
-    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --write; fi"
+    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --read; fi"
 
   yCartisianSolver_r:
     <<: *yarp-base

--- a/demos/robotGazebo/main.yml
+++ b/demos/robotGazebo/main.yml
@@ -25,7 +25,7 @@ services:
     deploy:
       placement:
         constraints: [node.role == manager]
-    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --write; fi"
+    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --read; fi"
 
 #------------------------------------------------------------------------------------------------
 

--- a/demos/speechToSpeech/main.yml
+++ b/demos/speechToSpeech/main.yml
@@ -31,7 +31,7 @@ services:
         constraints: [node.role == manager]
       restart_policy:
         condition: on-failure
-    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --write; fi"
+    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --read; fi"
   
 #------------------------------------------------------------------------------------------------
   yDemoGoogleSpeech:

--- a/demos/speechToText/composeGui.yml
+++ b/demos/speechToText/composeGui.yml
@@ -31,7 +31,7 @@ services:
     <<: *yarp-base
     devices: 
       - "/dev/snd:/dev/snd"
-    command: sh -c "yarp wait $$(echo $$(cat /root/.config/yarp/yarp_namespace.conf)); yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --rate 16000 --samples 16000"
+    command: sh -c "if [ -f "/root/.config/yarp/yarp_namespace.conf" ]; then yarp wait $$(echo $$(cat /root/.config/yarp/yarp_namespace.conf)); else yarp wait /root; fi; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --rate 16000 --samples 16000"
   
   yconnect_audio:
     <<: *yarp-base

--- a/demos/speechToText/composeGui.yml
+++ b/demos/speechToText/composeGui.yml
@@ -31,7 +31,7 @@ services:
     <<: *yarp-base
     devices: 
       - "/dev/snd:/dev/snd"
-    command: sh -c "yarp wait /root; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --rate 16000 --samples 16000"
+    command: sh -c "yarp wait $$(echo $$(cat /root/.config/yarp/yarp_namespace.conf)); yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --rate 16000 --samples 16000"
   
   yconnect_audio:
     <<: *yarp-base

--- a/demos/speechToText/main.yml
+++ b/demos/speechToText/main.yml
@@ -30,7 +30,7 @@ services:
         constraints: [node.role == manager]
       restart_policy:
         condition: on-failure
-    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --write; fi"
+    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --read; fi"
   
 #------------------------------------------------------------------------------------------------
   yDemoGoogleSpeech:

--- a/demos/startQA/composeGui.yml
+++ b/demos/startQA/composeGui.yml
@@ -32,7 +32,7 @@ services:
     <<: *yarp-base
     devices: 
       - "/dev/snd:/dev/snd"
-    command: sh -c "yarp wait /root; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --rate 16000 --samples 16000"
+    command: sh -c "if [ -f "/root/.config/yarp/yarp_namespace.conf" ]; then yarp wait $$(echo $$(cat /root/.config/yarp/yarp_namespace.conf)); else yarp wait /root; fi; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --rate 16000 --samples 16000"
   
   yconnect_audio:
     <<: *yarp-base

--- a/demos/startQA/main.yml
+++ b/demos/startQA/main.yml
@@ -34,7 +34,7 @@ services:
         constraints: [node.role == manager]
       restart_policy:
         condition: on-failure
-    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --write; fi"
+    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --read; fi"
   
 #------------------------------------------------------------------------------------------------
   yDemoGoogleSpeech:

--- a/demos/superviseCalib/main.yml
+++ b/demos/superviseCalib/main.yml
@@ -30,7 +30,7 @@ services:
         constraints: [node.role == manager]
       restart_policy:
         condition: on-failure
-    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --write; fi"
+    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --read; fi"
 
 #------------------------------------------------------------------------------------------------
   #Modules

--- a/demos/textToSpeech/main.yml
+++ b/demos/textToSpeech/main.yml
@@ -30,7 +30,7 @@ services:
         constraints: [node.role == manager]
       restart_policy:
         condition: on-failure
-    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --write; fi"
+    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --read; fi"
   
 #------------------------------------------------------------------------------------------------
 

--- a/demos/yarpBasicDeploy/main.yml
+++ b/demos/yarpBasicDeploy/main.yml
@@ -29,7 +29,7 @@ services:
       deploy:
         placement:
           constraints: [node.role == manager]
-      command: sh -c "yarp wait /root; yarpdev --device frameGrabber_nws_yarp --period 0.5 --width 640 --height 480"
+      command: sh -c "if [ -f "/root/.config/yarp/yarp_namespace.conf" ]; then yarp wait $$(echo $$(cat /root/.config/yarp/yarp_namespace.conf)); else yarp wait /root; fi; yarpdev --device frameGrabber_nws_yarp --period 0.5 --width 640 --height 480"
        #use network.peer ip address and port 8080 to see the containers status in browser (http://localhost:8080/)
     visualizer:
       image: dockersamples/visualizer:stable

--- a/demos/yarpBasicDeploy/main.yml
+++ b/demos/yarpBasicDeploy/main.yml
@@ -22,7 +22,7 @@ services:
       deploy:
         placement:
           constraints: [node.role == manager]
-      command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --write; fi"
+      command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --read; fi"
 
     ydevice:
       <<: *yarp-base

--- a/demos/yarpOpenFace/main.yml
+++ b/demos/yarpOpenFace/main.yml
@@ -29,7 +29,7 @@ services:
         constraints: [node.role == manager]
       restart_policy:
         condition: on-failure
-    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --write; fi"
+    command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --read; fi"
 
 #------------------------------------------------------------------------------------------------
 #Following services are configured in ./icub-main/app/default/scripts/cameras_calib.xml.template

--- a/scripts/appsAway_setupCluster.sh
+++ b/scripts/appsAway_setupCluster.sh
@@ -176,53 +176,7 @@ create_yarp_config_files()
   else
     mkdir -p ${APPSAWAY_APP_PATH}/${_YARP_CONFIG_FILES_PATH}
   fi
-
-
-
-
-  #######################################################START
- # if [ "${_YARP_BIN}" != "" ] 
- # then
- #   log "Checking if YARP server is running..."
- #   _YARP_IP_FOUND=$( $_YARP_BIN where | echo "$( sed -nr 's/.*is available at ip (.*) port.*/\1/p' )" )
- #   _YARP_PORT_FOUND=$( $_YARP_BIN where | echo "$( sed -nr 's/.*at ip '"$_YARP_IP_FOUND"' port (.*).*/\1/p' )" )
- #   _YARP_NAMESPACE_FOUND=$( $_YARP_BIN where | echo "$( sed -nr 's/.*Name server \/(.*) is available.*/\1/p' )" )
- #   if [ "$_YARP_IP_FOUND" != "" ]
- #   then
- #     log "A yarp server was found with ip $_YARP_IP_FOUND port $_YARP_PORT_FOUND with namespace /$_YARP_NAMESPACE_FOUND"
- #     _YARP_IP_CONF=$_YARP_IP_FOUND
- #     _YARP_PORT_CONF=$_YARP_PORT_FOUND
- #     _YARP_NAMESPACE_CONF=$_YARP_NAMESPACE_FOUND
- #   else
- #     _YARP_IP_CONF=$APPSAWAY_CONSOLENODE_ADDR
- #     _YARP_PORT_CONF=$_YARPSERVER_DEFAULT_PORT
- #     _YARP_NAMESPACE_CONF=$( $_YARP_BIN namespace | echo "$( sed -nr 's/.*YARP namespace: \/(.*).*/\1/p' )" )
- #     log "server not found, it will be launched with the following settings: ${APPSAWAY_CONSOLENODE_ADDR} ${_YARPSERVER_DEFAULT_PORT} ${_YARP_NAMESPACE_CONF}"
-
- #     # _YARP_IP_USER contains the yarp server IP address configured in console machine
- #     _YARP_IP_USER=$( $_YARP_BIN where | echo "$( sed -nr 's/.*Looking for name server on (.*), port.*/\1/p' )" )
- #     _YARP_PORT_USER=$( $_YARP_BIN where | echo "$( sed -nr 's/.*Looking for name server on '"$_YARP_IP_FOUND"', port number (.*).*/\1/p' )" )
- #     if [ "$_YARP_IP_USER" == "" ] 
- #     then
- #       #in this case the user using a custom namespace without setting the _<usernamespace>.conf file.
- #       exit_err "Missing the file _$_YARP_NAMESPACE_FOUND.conf "
- #     else
- #       if [ "$_YARP_IP_USER" != "$APPSAWAY_CONSOLENODE_ADDR" ] || [ "$_YARP_PORT_USER" != "$_YARPSERVER_DEFAULT_PORT" ] 
- #       then
- #          warn "Yarp server IP address/port in configuration file of this machine mismatches with IP Address/port used in the deployment. Yarp server will run on ${_YARP_IP_CONF} $_YARPSERVER_DEFAULT_PORT"
- #       fi
- #     fi
- #   fi
- # else
- #   log "yarp binary not found, using default settings for yarp server"
- #   _YARP_IP_CONF=$APPSAWAY_CONSOLENODE_ADDR
- #   _YARP_PORT_CONF=$_YARPSERVER_DEFAULT_PORT
- #   _YARP_NAMESPACE_CONF="$_YARPSERVER_DEFAULT_NAMESPACE"
- # fi
-#################################################### END
-
-
-
+  
   log "Preparing yarp server configuration ..."
   if [ "${_YARP_BIN}" == "" ] 
   then

--- a/scripts/converter.py
+++ b/scripts/converter.py
@@ -41,7 +41,7 @@ service_str = """
               constraints: [node.role == manager]
             restart_policy:
               condition: on-failure
-          command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --write; fi"
+          command: sh -c "yarp where | grep 'is available at ip' > /dev/null ; if [ ! $$? -eq 0 ]; then yarpserver --read; fi"
 """
 
 for m in modulelist:


### PR DESCRIPTION
With this PR different changes have been implemented in order to fix different issues when launching `yarpserver` through the deployment. In particular:
- we replaced `yarpserver --write` with `yarpserver --read` in all ymls in order to use the correct IP address when launching `yarpserver`, without creating connection issues between the host and the containers;
- we updated the ymls taking the correct namespace from the `yarp_namespace.conf` file and waiting for `/<namespace>` when launching a `yarp device` through the deployment; only in the particular case where the namespace is `/root`, since the `yarp_namespace.conf` file is not created, we instead wait for `/root`;
- we changed the way we set the YARP configuration in our `appsAway_setupCluster.sh`: summarizing we use the default YARP configuration ( <console_address> - 10000 - /root) if yarp is not installed, otherwise if it is installed but yarp is not running anywhere we use the console address, port 10000 and namespace of the console. 