### PR TITLE
Fixes to run deployment with no yarp installed

### DIFF
--- a/demos/robotGazebo/composeGui.yml
+++ b/demos/robotGazebo/composeGui.yml
@@ -23,4 +23,4 @@ services:
   #following service are configured in icub-main/app/iCubStartup/scripts/iCubStartup.xml.template
   gazebo:
     <<: *yarp-base
-    command: gazebo
+    command: sh -c "if [ -f "/root/.config/yarp/yarp_namespace.conf" ]; then yarp wait $$(echo $$(cat /root/.config/yarp/yarp_namespace.conf)); else yarp wait /root; fi; gazebo"

--- a/scripts/appsAway_checkAppRunning.sh
+++ b/scripts/appsAway_checkAppRunning.sh
@@ -6,6 +6,7 @@ source ./appsAway_setEnvironment.temp.sh
 _APPSAWAY_ENV_FILE="appsAway_setEnvironment.local.sh"
 _YARP_CONFIG_FILES_PATH="config_yarp"
 _YARP_NAMESPACE="/root"
+_YARP_BIN=$(which yarp || true)
 _NC='\033[0m' # No Color
 _RED='\033[0;31m'
 _GREEN='\033[0;32m'
@@ -219,13 +220,18 @@ merge_environment()
   log "replacing localhost with its ip..."
   sed -i 's/export APPSAWAY_CONSOLENODE_ADDR=localhost/export APPSAWAY_CONSOLENODE_ADDR='$(hostname -I | awk '{print $1}')'/g' appsAway_setEnvironment.local.sh
 
-  resourcePath=$(echo "$(yarp resource --context cameraCalibration --from icubEyes.ini)" | awk -F'"' '{print $2}' | awk -F'icubEyes.ini' '{print $1}')
-  resourcePathClean="$(echo -e "${resourcePath}" | tr -d '[:space:]')"
-  echo "export APPSAWAY_CALIB_CONTEXT=$resourcePathClean" >>appsAway_setEnvironment.local.sh
+  if [ "${_YARP_BIN}" != "" ] 
+  then
+    resourcePath=$(echo "$(yarp resource --context cameraCalibration --from icubEyes.ini)" | awk -F'"' '{print $2}' | awk -F'icubEyes.ini' '{print $1}')
+    resourcePathClean="$(echo -e "${resourcePath}" | tr -d '[:space:]')"
+    echo "export APPSAWAY_CALIB_CONTEXT=$resourcePathClean" >>appsAway_setEnvironment.local.sh
 
-  resourcePath=$(echo "$(yarp resource --context demoRedBall --from config.ini)" | awk -F'"' '{print $2}' | awk -F'config.ini' '{print $1}')
-  resourcePathClean="$(echo -e "${resourcePath}" | tr -d '[:space:]')"
-  echo "export APPSAWAY_DEMOREDBALL_CONTEXT=$resourcePathClean" >>appsAway_setEnvironment.local.sh
+    resourcePath=$(echo "$(yarp resource --context demoRedBall --from config.ini)" | awk -F'"' '{print $2}' | awk -F'config.ini' '{print $1}')
+    resourcePathClean="$(echo -e "${resourcePath}" | tr -d '[:space:]')"
+    echo "export APPSAWAY_DEMOREDBALL_CONTEXT=$resourcePathClean" >>appsAway_setEnvironment.local.sh
+  else
+    log "yarp binary not found, cameraCalibration and demoRedBall contexts will not be set"
+  fi
 
 }
 

--- a/scripts/appsAway_cleanupCluster.sh
+++ b/scripts/appsAway_cleanupCluster.sh
@@ -270,6 +270,15 @@ clean_up_swarm()
   docker swarm leave --force |& grep -v Error || true
 }
 
+clean_up_icubapps()
+{
+  for index in "${!nodes_addr_list[@]}"
+  do
+    log "Removing ${_OS_HOME_DIR}/${nodes_username_list[$index]}/${APPSAWAY_APP_PATH_NOT_CONSOLE} on node ${nodes_addr_list[$index]}..."
+    run_via_ssh_no_folder ${nodes_username_list[$index]} ${nodes_addr_list[$index]} "rm -rf ${_OS_HOME_DIR}/${nodes_username_list[$index]}/${APPSAWAY_APP_PATH_NOT_CONSOLE}"
+  done
+}
+
 main()
 { 
   nodes_addr_list=(${APPSAWAY_NODES_ADDR_LIST})
@@ -290,11 +299,15 @@ main()
   if [[ "$@" == *"swarm"* ]] ; then
     clean_up_swarm
   fi
+  if [[ "$@" == *"icubapps"* ]] ; then
+    clean_up_icubapps
+  fi
   if [[ "$@" == *"all"* ]] ; then
     log "About to cleanup the cluster..."
     clean_up_registry 
     clean_up_stack 
     clean_up_swarm
+    clean_up_icubapps
   fi
 }
 

--- a/scripts/appsAway_setupCluster.sh
+++ b/scripts/appsAway_setupCluster.sh
@@ -210,22 +210,7 @@ create_yarp_config_files()
       fi
     fi
   fi
-      
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  
   log "creating YARP config files in path ${APPSAWAY_APP_PATH}/${_YARP_CONFIG_FILES_PATH} with namespace /$_YARP_NAMESPACE_CONF, ip $_YARP_IP_CONF in port $_YARP_PORT_CONF"
   
   if [ "${_YARP_NAMESPACE_CONF}" == "$_YARPSERVER_DEFAULT_NAMESPACE" ]


### PR DESCRIPTION
This PR introduces the following changes to handle the deployment on a machine with no `yarp` installed:

- it detects the `cameraCalibration` and `demoRedBall` contexts only if `yarp` is installed on the console;
- it updates the `appsAway_cleanupCluster` to remove `iCubApps/${APPSAWAY_APP_NAME}` folder on all the machines in the cluster when we exit the deployment.

I also took the chance to update the `robotGazebo` `composeGui.yml` to wait for `yarp` to be up before running `gazebo`. 