### PR TITLE
Changing GUI from launching on host to launch from container

### DIFF
--- a/gui/main.py
+++ b/gui/main.py
@@ -243,6 +243,7 @@ class WidgetGallery(QDialog):
 
         #self.gui_dir = os.getcwd()
         self.gui_dir = os.path.join(os.getcwd(),"conf")
+        self.scripts_dir = os.path.join(os.environ.get('HOME'),"teamcode","appsAway","scripts")
 
         # read from .ini file here
         self.button_name_list = []
@@ -334,9 +335,11 @@ class WidgetGallery(QDialog):
         
         self.pushUpdateButton.setDefault(True)    
 
-        out = subprocess.Popen(['./appsAway_checkUpdates.sh'], 
-           stdout=subprocess.PIPE, 
-           stderr=subprocess.STDOUT)
+        with open(os.path.join(self.scripts_dir, 'mypipe'), 'w') as f:
+            f.write('./appsAway_checkUpdates.sh')
+#        out = subprocess.Popen(['./appsAway_checkUpdates.sh'], 
+#           stdout=subprocess.PIPE, 
+ #          stderr=subprocess.STDOUT)
         
         stdout,stderr = out.communicate()
 
@@ -642,6 +645,8 @@ class WidgetGallery(QDialog):
         self.startApplication()
         os.chdir(os.path.join(os.environ.get('HOME'),"teamcode","appsAway","scripts"))
         rc = subprocess.call("./appsAway_setEnvironment.local.sh")
+        #with open(os.path.join(self.scripts_dir, 'mypipe'), 'w') as f:
+        #  f.write("./appsAway_setEnvironment.local.sh")
             
     def stopProgressBar(self):
         self.pushStopButton.setEnabled(True)
@@ -650,9 +655,11 @@ class WidgetGallery(QDialog):
         if self.ansible.poll() == None:
           return
         self.timer.start(300000)
-        out = subprocess.Popen(['./appsAway_checkUpdates.sh'], 
-           stdout=subprocess.PIPE, 
-           stderr=subprocess.STDOUT)
+        with open(os.path.join(self.scripts_dir, 'mypipe'), 'w') as f:
+          f.write("./appsAway_checkUpdates.sh")
+        #out = subprocess.Popen(['./appsAway_checkUpdates.sh'], 
+        #   stdout=subprocess.PIPE, 
+        #   stderr=subprocess.STDOUT)
         
         stdout,stderr = out.communicate()
 
@@ -670,11 +677,14 @@ class WidgetGallery(QDialog):
         self.pushUpdateButton.setText("Installing....")
         # then we change working directory
         #os.chdir("ansible_setup") 
-        os.chdir(os.path.join(os.environ.get('HOME'),"teamcode","appsAway","scripts","ansible_setup"))
-        rc = subprocess.call("./setup_hosts_ini.sh")
-        self.ansible = subprocess.Popen(['make', 'prepare'])
+        with open(os.path.join(self.scripts_dir, 'mypipe'), 'w') as f:
+          f.write("cd ansible_setup && ./setup_hosts_ini.sh && make prepare_all && cd ..")
+
+        #os.chdir(os.path.join(os.environ.get('HOME'),"teamcode","appsAway","scripts","ansible_setup"))
+        #rc = subprocess.call("./setup_hosts_ini.sh")
+        #self.ansible = subprocess.Popen(['make', 'prepare'])
         #os.chdir("..") 
-        os.chdir(os.path.join(os.environ.get('HOME'),"teamcode","appsAway","scripts"))
+        #os.chdir(os.path.join(os.environ.get('HOME'),"teamcode","appsAway","scripts"))
 
     def startApplication(self):
         print("starting application")
@@ -713,7 +723,11 @@ class WidgetGallery(QDialog):
             elif buttonOption.button == None and not buttonOption.inputBox.isEnabled:
               os.environ[buttonOption.varName] = ""
         self.setupEnvironment()
-        rc = subprocess.Popen("./appsAway_startApp.sh", shell=True)
+
+        with open(os.path.join(self.scripts_dir, 'mypipe'), 'w') as f:
+          f.write("./appsAway_startApp.sh")
+
+        #rc = subprocess.Popen("./appsAway_startApp.sh", shell=True)
         #self.rc = subprocess.Popen("./appsAway_startApp.sh", stdout=subprocess.PIPE, shell=True)
     
     def stopApplication(self):
@@ -736,7 +750,10 @@ class WidgetGallery(QDialog):
             buttonOption.inputBox.setEnabled(True)
           self.checkDependencies(buttonOption)      
 
-        rc = subprocess.call("./appsAway_stopApp.sh")
+        with open(os.path.join(self.scripts_dir, 'mypipe'), 'w') as f:
+          f.write("./appsAway_stopApp.sh")
+
+        #rc = subprocess.call("./appsAway_stopApp.sh")
 
     def setupEnvironment(self):
         # os.chdir(os.path.join(os.environ.get('HOME'), "teamcode","appsAway","demos", os.environ.get('APPSAWAY_APP_NAME')))
@@ -847,8 +864,10 @@ class WidgetGallery(QDialog):
 
         os.chdir(os.path.join(os.environ.get('HOME'), "teamcode","appsAway","scripts"))
           
+        with open(os.path.join(self.scripts_dir, 'mypipe'), 'w') as f:
+          f.write("./appsAway_copyFiles.sh")
         # now we copy all the files to their respective machines
-        rc = subprocess.call("./appsAway_copyFiles.sh")
+        #rc = subprocess.call("./appsAway_copyFiles.sh")
 
     # overload the closing function to close the watchdog
     def exec_(self):

--- a/gui/main.py
+++ b/gui/main.py
@@ -237,7 +237,7 @@ class WidgetGallery(QDialog):
         self.image = "" #'src/main/images/redball.jpg'
 
         self.rc = None #inits the subprocess
-        self.ansible = subprocess.Popen(['true'])
+        #self.ansible = subprocess.Popen(['true'])
 
         self.button_list = []
 
@@ -341,7 +341,7 @@ class WidgetGallery(QDialog):
 #           stdout=subprocess.PIPE, 
  #          stderr=subprocess.STDOUT)
         
-        stdout,stderr = out.communicate()
+        #stdout,stderr = out.communicate()
 
         if b"true" in stdout:
           self.pushUpdateButton.setEnabled(True)
@@ -652,16 +652,20 @@ class WidgetGallery(QDialog):
         self.pushStopButton.setEnabled(True)
 
     def checkForUpdates(self):
-        if self.ansible.poll() == None:
-          return
-        self.timer.start(300000)
+        #if self.ansible.poll() == None:
+        #  return
+        #self.timer.start(300000)
         with open(os.path.join(self.scripts_dir, 'mypipe'), 'w') as f:
-          f.write("./appsAway_checkUpdates.sh")
+          f.write("./appsAway_checkUpdates.sh > mypipe")
         #out = subprocess.Popen(['./appsAway_checkUpdates.sh'], 
         #   stdout=subprocess.PIPE, 
         #   stderr=subprocess.STDOUT)
-        
-        stdout,stderr = out.communicate()
+        while True:
+          with open(os.path.join(self.scripts_dir, 'mypipe'), 'r') as f:
+            stdout = f.read()
+            if stdout:
+              break
+        #stdout,stderr = out.communicate()
 
         if b"true" in stdout:
           self.pushUpdateButton.setEnabled(True)
@@ -672,7 +676,7 @@ class WidgetGallery(QDialog):
 
     def startUpdate(self):
         # first we pause the timer
-        self.timer.start(1000)
+        #self.timer.start(1000)
         self.pushUpdateButton.setEnabled(False)
         self.pushUpdateButton.setText("Installing....")
         # then we change working directory

--- a/gui/main.py
+++ b/gui/main.py
@@ -336,12 +336,18 @@ class WidgetGallery(QDialog):
         self.pushUpdateButton.setDefault(True)    
 
         with open(os.path.join(self.scripts_dir, 'mypipe'), 'w') as f:
-            f.write('./appsAway_checkUpdates.sh')
+            f.write('./appsAway_checkUpdates.sh > mypipe')
 #        out = subprocess.Popen(['./appsAway_checkUpdates.sh'], 
 #           stdout=subprocess.PIPE, 
  #          stderr=subprocess.STDOUT)
         
         #stdout,stderr = out.communicate()
+
+        while True:
+          with open(os.path.join(self.scripts_dir, 'mypipe'), 'r') as f:
+            stdout = f.read()
+            if stdout:
+              break
 
         if b"true" in stdout:
           self.pushUpdateButton.setEnabled(True)

--- a/gui/main.py
+++ b/gui/main.py
@@ -116,10 +116,12 @@ class OptionButton():
         elif button_type == ButtonType.FILE_INPUT:
             inputButton = QLineEdit(widget_gallery)
             inputButton.setPlaceholderText(var_name)
-            button = QPushButton(button_text)
+            # commented this line for now, since the "choose file" option doesn't work from inside container
+            #button = QPushButton(button_text)
             if initial_setting == "off":
               inputButton.setEnabled(False)
-              button.setEnabled(False)
+              # commented this line for now, since the "choose file" option doesn't work from inside container
+              #button.setEnabled(False)
 
         elif button_type == ButtonType.TOGGLE_BUTTON:
             inputButton = None
@@ -430,7 +432,8 @@ class WidgetGallery(QDialog):
           if buttonOption.varType == 'fileInput':
             #layout.addWidget(buttonOption.button)
             #layout.addWidget(buttonOption.inputBox)
-            buttonOption.button.clicked.connect(self.openFile(buttonOption))
+            # commented this line for now, since the "choose file" option doesn't work from inside container
+            #buttonOption.button.clicked.connect(self.openFile(buttonOption))
             buttonOption.inputBox.textChanged.connect(self.checkToggleState(buttonOption))
 
           if buttonOption.varType == 'toggleButton':

--- a/gui/main.py
+++ b/gui/main.py
@@ -241,7 +241,8 @@ class WidgetGallery(QDialog):
 
         self.button_list = []
 
-        self.gui_dir = os.getcwd()
+        #self.gui_dir = os.getcwd()
+        self.gui_dir = os.path.join(os.getcwd(),"conf")
 
         # read from .ini file here
         self.button_name_list = []

--- a/gui/main.py
+++ b/gui/main.py
@@ -577,7 +577,7 @@ class WidgetGallery(QDialog):
         sel_voice=[el.button.currentText() for el in list(filter(lambda x: x.varName == 'VOICE_NAME_INPUT', self.button_list)) ] #to avoid another for loop on all the buttons, we do a filter 
         sel_lang=[el.button.currentText() for el in list(filter(lambda x: x.varName == 'LANGUAGE_SYNTHESIS_INPUT' or x.varName == 'LANGUAGE_INPUT', self.button_list)) ] #here we have the selected voice
         
-        rc = subprocess.call(["play", os.path.join('root','iCubApps','Archive','language '+ sel_lang[0] + '_' + sel_voice[0] + '.mp3')])
+        rc = subprocess.call(["play", os.path.join('/','root','iCubApps','Archive','language '+ sel_lang[0] + '_' + sel_voice[0] + '.mp3')])
 
       return play
 

--- a/gui/main.py
+++ b/gui/main.py
@@ -118,6 +118,7 @@ class OptionButton():
             inputButton.setPlaceholderText(var_name)
             # commented this line for now, since the "choose file" option doesn't work from inside container
             #button = QPushButton(button_text)
+            button = None
             if initial_setting == "off":
               inputButton.setEnabled(False)
               # commented this line for now, since the "choose file" option doesn't work from inside container
@@ -335,30 +336,25 @@ class WidgetGallery(QDialog):
 
         layout = QVBoxLayout()
         
-        self.pushUpdateButton.setDefault(True)    
+        #self.pushUpdateButton.setDefault(True)    
 
-        with open(os.path.join(self.scripts_dir, 'mypipe'), 'w') as f:
-            f.write('./appsAway_checkUpdates.sh > mypipe_to_gui')
-#        out = subprocess.Popen(['./appsAway_checkUpdates.sh'], 
-#           stdout=subprocess.PIPE, 
- #          stderr=subprocess.STDOUT)
-        
-        #stdout,stderr = out.communicate()
+        #with open(os.path.join(self.scripts_dir, 'mypipe'), 'w') as f:
+        #    f.write('./appsAway_checkUpdates.sh > mypipe_to_gui')
 
-        while True:
-          with open(os.path.join(self.scripts_dir, 'mypipe_to_gui'), 'r') as f:
-            stdout = f.read()
-            if stdout:
-              break
+        #while True:
+        #  with open(os.path.join(self.scripts_dir, 'mypipe_to_gui'), 'r') as f:
+        #    stdout = f.read()
+        #    if stdout:
+        #      break
 
-        if "true" in stdout:
-          self.pushUpdateButton.setEnabled(True)
-          self.pushUpdateButton.setText("Update Available")
-        elif "false" in stdout:
-          self.pushUpdateButton.setEnabled(False)
-          self.pushUpdateButton.setText("Everything is Up to Date!")
+        #if "true" in stdout:
+        #  self.pushUpdateButton.setEnabled(True)
+        #  self.pushUpdateButton.setText("Update Available")
+        #elif "false" in stdout:
+        #  self.pushUpdateButton.setEnabled(False)
+        #  self.pushUpdateButton.setText("Everything is Up to Date!")
 
-        layout.addWidget(self.pushUpdateButton)
+        #layout.addWidget(self.pushUpdateButton)
 
 
         pixmap = QPixmap(self.image)
@@ -373,7 +369,7 @@ class WidgetGallery(QDialog):
         layout.setAlignment(Qt.AlignCenter)
         self.topGroupBox.setLayout(layout)
 
-        self.pushUpdateButton.clicked.connect(self.startUpdate)
+        #self.pushUpdateButton.clicked.connect(self.startUpdate)
     
 ########################################################## right options ###########################################################################
 ####################################################################################################################################################

--- a/scripts/appsAway_checkAppRunning.sh
+++ b/scripts/appsAway_checkAppRunning.sh
@@ -108,31 +108,31 @@ merge_environment()
     log "an app was detected running in this setup, merging cluster definitions..."
     #an app is already running, so we need to merge the environment
     echo '#! /bin/bash' >appsAway_setEnvironment.local.sh
-    cat appsAway_setEnvironment.temp.sh | grep "ROBOT_NAME=" >>appsAway_setEnvironment.local.sh
-    cat appsAway_setEnvironment.temp.sh | grep "APPSAWAY_APP_NAME=" >>appsAway_setEnvironment.local.sh
-    cat appsAway_setEnvironment.temp.sh | grep "APPSAWAY_USER_NAME=" >>appsAway_setEnvironment.local.sh
-    cat appsAway_setEnvironment.temp.sh | grep "APPSAWAY_APP_PATH=" >>appsAway_setEnvironment.local.sh
-    cat appsAway_setEnvironment.temp.sh | grep "APPSAWAY_CONSOLENODE_ADDR=" >>appsAway_setEnvironment.local.sh
-    cat appsAway_setEnvironment.temp.sh | grep "APPSAWAY_CONSOLENODE_USERNAME=" >>appsAway_setEnvironment.local.sh
+    cat appsAway_setEnvironment.temp.sh | grep "ROBOT_NAME=" >>appsAway_setEnvironment.local.sh || true
+    cat appsAway_setEnvironment.temp.sh | grep "APPSAWAY_APP_NAME=" >>appsAway_setEnvironment.local.sh || true
+    cat appsAway_setEnvironment.temp.sh | grep "APPSAWAY_USER_NAME=" >>appsAway_setEnvironment.local.sh || true
+    cat appsAway_setEnvironment.temp.sh | grep "APPSAWAY_APP_PATH=" >>appsAway_setEnvironment.local.sh || true
+    cat appsAway_setEnvironment.temp.sh | grep "APPSAWAY_CONSOLENODE_ADDR=" >>appsAway_setEnvironment.local.sh || true
+    cat appsAway_setEnvironment.temp.sh | grep "APPSAWAY_CONSOLENODE_USERNAME=" >>appsAway_setEnvironment.local.sh || true
     #################################################################################
     # first we check if the GUI machine is already defined in the local environment #
     #################################################################################
-    echo "checking for GUI"
+    #echo "checking for GUI"
     _GUI_EXISTS=$( echo "$( cat temp_local_env.sh | grep -c "APPSAWAY_GUINODE_ADDR=" )" )
-    echo $_GUI_EXISTS
+    #echo $_GUI_EXISTS
     if (( $_GUI_EXISTS > 0 ))
     then
       # if it was already defined, we keep this and discard the new
-      cat temp_local_env.sh | grep "APPSAWAY_GUINODE_ADDR=" >>appsAway_setEnvironment.local.sh
-      cat temp_local_env.sh | grep "APPSAWAY_GUINODE_USERNAME=" >>appsAway_setEnvironment.local.sh
+      cat temp_local_env.sh | grep "APPSAWAY_GUINODE_ADDR=" >>appsAway_setEnvironment.local.sh || true
+      cat temp_local_env.sh | grep "APPSAWAY_GUINODE_USERNAME=" >>appsAway_setEnvironment.local.sh || true
     else
       # if it was not defined, we check if it is defined in the new environment (temp)
       _GUI_EXISTS=$( echo "$( cat appsAway_setEnvironment.temp.sh | grep -c "APPSAWAY_GUINODE_ADDR=" )" )
       if (( $_GUI_EXISTS > 0 ))
       then
         # if it is defined in the new environment, and not in the old, we use the new definition
-        cat appsAway_setEnvironment.temp.sh | grep "APPSAWAY_GUINODE_ADDR=" >>appsAway_setEnvironment.local.sh
-        cat appsAway_setEnvironment.temp.sh | grep "APPSAWAY_GUINODE_USERNAME=" >>appsAway_setEnvironment.local.sh
+        cat appsAway_setEnvironment.temp.sh | grep "APPSAWAY_GUINODE_ADDR=" >>appsAway_setEnvironment.local.sh || true
+        cat appsAway_setEnvironment.temp.sh | grep "APPSAWAY_GUINODE_USERNAME=" >>appsAway_setEnvironment.local.sh || true
       fi
     fi
     #################################################################################
@@ -142,16 +142,16 @@ merge_environment()
     if (( $_HEAD_EXISTS > 0 ))
     then
       # if it was already defined, we keep this and discard the new
-      cat temp_local_env.sh | grep "APPSAWAY_ICUBHEADNODE_ADDR=" >>appsAway_setEnvironment.local.sh
-      cat temp_local_env.sh | grep "APPSAWAY_ICUBHEADNODE_USERNAME=" >>appsAway_setEnvironment.local.sh
+      cat temp_local_env.sh | grep "APPSAWAY_ICUBHEADNODE_ADDR=" >>appsAway_setEnvironment.local.sh || true
+      cat temp_local_env.sh | grep "APPSAWAY_ICUBHEADNODE_USERNAME=" >>appsAway_setEnvironment.local.sh || true
     else
       # if it was not defined, we check if it is defined in the new environment (temp)
       _HEAD_EXISTS=$( echo "$( cat appsAway_setEnvironment.temp.sh | grep -c "APPSAWAY_ICUBHEADNODE_ADDR=" )" )
       if (( $_HEAD_EXISTS > 0 ))
       then
         # if it is defined in the new environment, and not in the old, we use the new definition
-        cat appsAway_setEnvironment.temp.sh | grep "APPSAWAY_ICUBHEADNODE_ADDR=" >>appsAway_setEnvironment.local.sh
-        cat appsAway_setEnvironment.temp.sh | grep "APPSAWAY_ICUBHEADNODE_USERNAME=" >>appsAway_setEnvironment.local.sh
+        cat appsAway_setEnvironment.temp.sh | grep "APPSAWAY_ICUBHEADNODE_ADDR=" >>appsAway_setEnvironment.local.sh || true
+        cat appsAway_setEnvironment.temp.sh | grep "APPSAWAY_ICUBHEADNODE_USERNAME=" >>appsAway_setEnvironment.local.sh || true
       fi
     fi
     ###############################################################################
@@ -171,22 +171,22 @@ merge_environment()
     for image_index in "${!_IMAGE_LIST_NEW[@]}"
     do
       _IMAGE_PRESENT=false
-      echo "new image: ${_IMAGE_LIST_NEW[$image_index]}"
+      #echo "new image: ${_IMAGE_LIST_NEW[$image_index]}"
       # we do chained loops because we want to test the exact image names
       for image_local in ${!_IMAGE_LIST_LOCAL[@]}
       do
-        echo "local image: ${_IMAGE_LIST_LOCAL[$image_local]}"
+        #echo "local image: ${_IMAGE_LIST_LOCAL[$image_local]}"
         if [[ "${_IMAGE_LIST_LOCAL[$image_local]}" == "${_IMAGE_LIST_NEW[$image_index]}" ]]
         then
           # if it is present, we set the flag to true
-          echo "checking image ${_IMAGE_LIST_NEW[$image_index]}"
+          #echo "checking image ${_IMAGE_LIST_NEW[$image_index]}"
           _IMAGE_PRESENT=true
         fi
       done
-      echo "status: $_IMAGE_PRESENT"
+      #echo "status: $_IMAGE_PRESENT"
       if [[ $_IMAGE_PRESENT == "false" ]]
       then
-        echo "was not present"
+        #echo "Image was not present"
         _IMAGE_LIST_LOCAL+=(${_IMAGE_LIST_NEW[$image_index]})
         _VERSIONS_LIST_LOCAL+=(${_VERSIONS_LIST_NEW[$image_index]})
         _YARP_VERSIONS_LIST_LOCAL+=(${_YARP_VERSIONS_LIST_NEW[$image_index]})
@@ -201,15 +201,15 @@ merge_environment()
     echo "export APPSAWAY_ICUB_FIRMWARE=\"${_ICUB_FIRMWARE_LIST_LOCAL[@]}\"" >>appsAway_setEnvironment.local.sh
     echo "export APPSAWAY_TAGS=\"${_TAGS_LIST_LOCAL[@]}\"" >>appsAway_setEnvironment.local.sh
 
-    cat appsAway_setEnvironment.temp.sh | grep "APPSAWAY_DEPLOY_YAML_FILE_LIST=" >>appsAway_setEnvironment.local.sh
-    cat appsAway_setEnvironment.temp.sh | grep "APPSAWAY_GUI_YAML_FILE_LIST=" >>appsAway_setEnvironment.local.sh
-    cat appsAway_setEnvironment.temp.sh | grep "APPSAWAY_HEAD_YAML_FILE_LIST=" >>appsAway_setEnvironment.local.sh
+    cat appsAway_setEnvironment.temp.sh | grep "APPSAWAY_DEPLOY_YAML_FILE_LIST=" >>appsAway_setEnvironment.local.sh || true
+    cat appsAway_setEnvironment.temp.sh | grep "APPSAWAY_GUI_YAML_FILE_LIST=" >>appsAway_setEnvironment.local.sh || true
+    cat appsAway_setEnvironment.temp.sh | grep "APPSAWAY_HEAD_YAML_FILE_LIST=" >>appsAway_setEnvironment.local.sh || true
 
     # if a stack is already created, we want to add to the old stack, not create a new
-    cat temp_local_env.sh | grep "APPSAWAY_STACK_NAME=" >>appsAway_setEnvironment.local.sh
+    cat temp_local_env.sh | grep "APPSAWAY_STACK_NAME=" >>appsAway_setEnvironment.local.sh || true
 
-    cat appsAway_setEnvironment.temp.sh | grep "APPSAWAY_NODES_ADDR_LIST=" >>appsAway_setEnvironment.local.sh
-    cat appsAway_setEnvironment.temp.sh | grep "APPSAWAY_NODES_USERNAME_LIST=" >>appsAway_setEnvironment.local.sh
+    cat appsAway_setEnvironment.temp.sh | grep "APPSAWAY_NODES_ADDR_LIST=" >>appsAway_setEnvironment.local.sh || true
+    cat appsAway_setEnvironment.temp.sh | grep "APPSAWAY_NODES_USERNAME_LIST=" >>appsAway_setEnvironment.local.sh || true
   else
     log "no app detected running on the system, initializing..."
     # if there is no app running, we just overwrite the local environment file

--- a/scripts/appsAway_guiLaunch.yml
+++ b/scripts/appsAway_guiLaunch.yml
@@ -1,0 +1,35 @@
+version: "3.7"
+
+x-gui: &gui-container
+  image: icubteamcode/gui-img:latest
+  environment:
+    - PULSE_SERVER=unix:${XDG_RUNTIME_DIR}/pulse/native
+    - QT_X11_NO_MITSHM=1
+    - DISPLAY=${DISPLAY}
+    - XAUTHORITY=/root/.Xauthority
+    - XDG_RUNTIME_DIR
+  volumes:
+    - "/tmp/.X11-unix:/tmp/.X11-unix"
+    - "${XAUTHORITY}:/root/.Xauthority"
+    - "${HOME}/teamcode/appsAway/demos/${APPSAWAY_APP_NAME}/gui:/target/appGUI/conf"
+    - "${HOME}/teamcode:/root/teamcode"
+    - "${APPSAWAY_APP_PATH}:/root/iCubApps"
+    - "${XDG_RUNTIME_DIR}/pulse/native:${XDG_RUNTIME_DIR}/pulse/native"
+    - "~/.config/pulse/cookie:/root/.config/pulse/cookie"
+    - "/dev:/dev"
+  network_mode: "host"
+  privileged: true
+
+# ${HOME}/teamcode/appsAway/demos/${APPSAWAY_APP_NAME}/gui
+# this is where all the gui images, conf, etc are
+
+# ${HOME}/teamcode
+# this is so we can access the environment script, along with the pipe files
+
+# ${APPSAWAY_APP_PATH}
+# this is so we can read from the .env file for the demo
+  
+services:
+  appGUI:
+    <<: *gui-container
+    command: ./appGUI

--- a/scripts/appsAway_setupGui.sh
+++ b/scripts/appsAway_setupGui.sh
@@ -1,0 +1,143 @@
+#!/bin/bash -e
+#set -x
+# ##############################################################################
+# SCRIPT NAME: appsAway_setupRegistry.sh
+#
+# DESCRIPTION: set up the local registry 
+#
+# NOTE: the node where this script is executed is selected as swarm master
+#
+# AUTHOR : Alexandre Antunes / Vadim Tikhanoff
+#
+# LATEST MODIFICATION DATE (YYYY-MM-DD) : 2021-11-11
+#
+_SCRIPT_VERSION="1.0"          # Sets version variable
+#
+_SCRIPT_TEMPLATE_VERSION="1.1.0" #
+#
+# ##############################################################################
+# Defaults
+# local variable name starts with "_"
+_NC='\033[0m' # No Color
+_RED='\033[0;31m'
+_GREEN='\033[0;32m'
+_BLUE='\033[0;34m'
+_YELLOW='\033[1;33m'
+_PURPLE='\033[1;35m'
+_LGRAY='\033[0;37m'
+_DOCKER_COMPOSE_BIN_CONSOLE=$(which docker-compose || true)
+_APPSAWAY_ENV_FILE="appsAway_setEnvironment.local.sh"
+# ##############################################################################
+print_defs ()
+{
+  echo "Default parameters are"
+  echo " _SCRIPT_TEMPLATE_VERSION is $_SCRIPT_TEMPLATE_VERSION"
+  echo " _SCRIPT_VERSION is $_SCRIPT_VERSION"
+  echo " _APPSAWAY_ENV_FILE is $_APPSAWAY_ENV_FILE"
+}
+
+usage ()
+{
+  echo "SCRIPT DESCRIPTION"
+
+  echo "Usage: $0 [options]"
+  echo "options are :"
+
+  echo "  -d : print defaults"
+  echo "  -v : print version"
+  echo "  -h : print this help"
+}
+
+log() {
+  echo -e "${_BLUE}$(date +%d-%m-%Y) - $(date +%H:%M:%S) : $1${_NC}"
+}
+
+warn() {
+  echo -e "${_YELLOW}$(date +%d-%m-%Y) - $(date +%H:%M:%S) WARNING : $1${_NC}"
+}
+
+error() {
+  echo -e "${_RED}$(date +%d-%m-%Y) - $(date +%H:%M:%S) ERROR : $1${_NC}"
+}
+
+exit_err () {
+	error "$1"
+	exit 1
+}
+
+print_version() {
+  echo "Script version is $_SCRIPT_VERSION based of Template version $_SCRIPT_TEMPLATE_VERSION"
+}
+
+parse_opt() {
+  while getopts hdv opt
+  do
+    case "$opt" in
+    h)
+      usage
+      exit 0
+      ;;
+    d)
+      print_defs
+      exit 0
+      ;;
+    v)
+      print_version
+      exit 0
+      ;;
+    \?) # unknown flag
+      usage
+      exit 1
+      ;;
+    esac
+  done
+}
+
+init()
+{
+ if [ "${_DOCKER_COMPOSE_BIN_CONSOLE}" == "" ]; then
+   exit_err "docker-compose binary not found in the console node"
+ fi
+ if [ ! -f "${_APPSAWAY_ENV_FILE}" ]; then
+   exit_err "enviroment file ${_APPSAWAY_ENV_FILE} does not exist"
+ fi
+ source ${_APPSAWAY_ENV_FILE}
+ log "$0 STARTED"
+}
+
+fini()
+{
+  log "$0 ENDED "
+}
+
+check_gui()
+{
+  if [[ -p "mypipe" ]]; then
+    rm mypipe
+  fi
+  if [[ -p "mypipe_to_gui" ]]; then
+    rm mypipe_to_gui
+  fi
+  mkfifo mypipe
+  mkfifo mypipe_to_gui
+  # HERE THERE BE DOCKER-COMPOSE UP
+  ${_DOCKER_COMPOSE_BIN_CONSOLE} -f appsAway_guiLaunch.yml pull
+  ${_DOCKER_COMPOSE_BIN_CONSOLE} -f appsAway_guiLaunch.yml up --detach
+  while true
+  do
+    eval "$(cat mypipe)"
+  done
+  rm mypipe
+  rm mypipe_to_gui
+}
+
+main()
+{ 
+  check_gui
+}
+
+parse_opt "$@"
+init
+main
+fini
+exit 0


### PR DESCRIPTION
This PR introduces the recent changes made to the GUI. as part of issue #810 

We have changed the following:

- The deployment GUI is now launched from a container, instead of installing and launching from the host machine. 
- The deployment of the GUI image is done by the `appsAway_setupGui.sh` script. The script also initializes the two pipe files to communicate to and from the GUI.

This part of the PR adds the `appsAway_setuoGui.sh` script responsible for launching and communicating with the GUI. The deployment of the container is done by using a compose file `appsAway_guiLaunch.yml` which shares all the required devices and starts the GUI itself. Finally, it introduces changes to the `main.py` to account for the new way the GUI operates, using `pipe` files to launch the commands instead of launching the scripts directly.

This PR should be merged **before** [the one in code](https://github.com/icub-tech-iit/code/pull/876). **It introduces breaking changes to the main.py, so they should be performed as close to each other as possible.**