### PR TITLE
Wait for swarm to pull the images

### DIFF
--- a/scripts/appsAway_startApp.sh
+++ b/scripts/appsAway_startApp.sh
@@ -260,6 +260,7 @@ run_deploy()
         log "waiting for $service_name to pull $image_name"
       fi
       count=$(( count + 1 ))
+      sleep 0.1 # to relax the cpu 
     done
   done < <(${_DOCKER_BIN} service ls --format "{{.ID}}")
 }


### PR DESCRIPTION
This PR adds to `appsAway_startApp.sh` an additional check to verify the current state of each service. We now wait until the `Preparing` phase has finished before launching the services.