### PR TITLE
Make import/export in funnythings GUI optional

### DIFF
--- a/demos/funnyThingsApp/composeGui.yml
+++ b/demos/funnyThingsApp/composeGui.yml
@@ -12,7 +12,7 @@ x-yarp-base: &yarp-base
     - "${XAUTHORITY}:/root/.Xauthority"
     - "${HOME}/${YARP_CONF_PATH}:/root/.config/yarp"
     - "/dev:/dev"
-    - "${FILE_IMPORT_EXPORT_PATH}:/root/shared-files:rw"
+    - "${FILE_IMPORT_EXPORT_PATH:-/tmp/empty-dir}:/root/shared-files:rw"
   network_mode: "host"
   privileged: true
 

--- a/scripts/appsAway_setupCluster.sh
+++ b/scripts/appsAway_setupCluster.sh
@@ -362,6 +362,40 @@ copy_yarp_files()
   done
 }
 
+create_empty_dir() # we create an empty directory in /tmp/empty-dir, useful e.g. as a default for sharing empty volumes in docker
+{
+  _EMPTY_DIR_COMMAND="mkdir -p /tmp/empty-dir; rm -r /tmp/empty-dir/* 2>/dev/null"
+  
+  # console
+  ${_EMPTY_DIR_COMMAND}
+  
+  # head
+  if [ "$APPSAWAY_ICUBHEADNODE_ADDR" != "" ]; then
+    ${_SSH_BIN} ${_SSH_PARAMS} ${APPSAWAY_ICUBHEADNODE_USERNAME}@${APPSAWAY_ICUBHEADNODE_ADDR} ${_EMPTY_DIR_COMMAND}
+  fi
+
+  #gui
+  if [ "$APPSAWAY_GUINODE_ADDR" != "" ]; then
+    ${_SSH_BIN} ${_SSH_PARAMS} ${APPSAWAY_GUINODE_USERNAME}@${APPSAWAY_GUINODE_ADDR} ${_EMPTY_DIR_COMMAND}
+  fi
+
+  # workers
+  iter=0
+  for node in ${_WORKER_NODE_LIST[@]}
+  do
+    ${_SSH_BIN} ${_SSH_PARAMS} ${_WORKER_USERNAME_LIST[iter]}@${_WORKER_NODE_LIST[iter]} ${_EMPTY_DIR_COMMAND}
+    iter=$((iter+1))
+  done
+  
+  # cuda
+  iter=0
+  for node in ${_CUDA_NODE_LIST[@]}
+  do
+    ${_SSH_BIN} ${_SSH_PARAMS} ${_CUDA_USERNAME_LIST[iter]}@${_CUDA_NODE_LIST[iter]} ${_EMPTY_DIR_COMMAND}
+    iter=$((iter+1))
+  done
+}
+
 find_docker_images()
 {
   APPSAWAY_IMAGES_LIST=($APPSAWAY_IMAGES)
@@ -416,6 +450,7 @@ main()
   create_yarp_config_files
   create_env_file
   copy_yarp_files
+  create_empty_dir
 }
 
 parse_opt "$@"

--- a/scripts/appsAway_setupCluster.sh
+++ b/scripts/appsAway_setupCluster.sh
@@ -364,26 +364,28 @@ copy_yarp_files()
 
 create_empty_dir() # we create an empty directory in /tmp/empty-dir, useful e.g. as a default for sharing empty volumes in docker
 {
-  _EMPTY_DIR_COMMAND="mkdir -p /tmp/empty-dir; rm -r /tmp/empty-dir/* 2>/dev/null"
+  _MAKE_EMPTY_DIR_COMMAND="mkdir -p /tmp/empty-dir"
+  _REMOVE_EMPTY_DIR_CONTENT="rm -rf /tmp/empty-dir/*"
   
   # console
-  ${_EMPTY_DIR_COMMAND}
-  
+  ${_MAKE_EMPTY_DIR_COMMAND}
+  ${_REMOVE_EMPTY_DIR_CONTENT}
+
   # head
   if [ "$APPSAWAY_ICUBHEADNODE_ADDR" != "" ]; then
-    ${_SSH_BIN} ${_SSH_PARAMS} ${APPSAWAY_ICUBHEADNODE_USERNAME}@${APPSAWAY_ICUBHEADNODE_ADDR} ${_EMPTY_DIR_COMMAND}
+    ${_SSH_BIN} ${_SSH_PARAMS} ${APPSAWAY_ICUBHEADNODE_USERNAME}@${APPSAWAY_ICUBHEADNODE_ADDR} "${_MAKE_EMPTY_DIR_COMMAND} ; ${_REMOVE_EMPTY_DIR_CONTENT}" 
   fi
 
   #gui
   if [ "$APPSAWAY_GUINODE_ADDR" != "" ]; then
-    ${_SSH_BIN} ${_SSH_PARAMS} ${APPSAWAY_GUINODE_USERNAME}@${APPSAWAY_GUINODE_ADDR} ${_EMPTY_DIR_COMMAND}
+    ${_SSH_BIN} ${_SSH_PARAMS} ${APPSAWAY_GUINODE_USERNAME}@${APPSAWAY_GUINODE_ADDR} "${_MAKE_EMPTY_DIR_COMMAND} ; ${_REMOVE_EMPTY_DIR_CONTENT}"
   fi
 
   # workers
   iter=0
   for node in ${_WORKER_NODE_LIST[@]}
   do
-    ${_SSH_BIN} ${_SSH_PARAMS} ${_WORKER_USERNAME_LIST[iter]}@${_WORKER_NODE_LIST[iter]} ${_EMPTY_DIR_COMMAND}
+    ${_SSH_BIN} ${_SSH_PARAMS} ${_WORKER_USERNAME_LIST[iter]}@${_WORKER_NODE_LIST[iter]} "${_MAKE_EMPTY_DIR_COMMAND} ; ${_REMOVE_EMPTY_DIR_CONTENT}"
     iter=$((iter+1))
   done
   
@@ -391,7 +393,7 @@ create_empty_dir() # we create an empty directory in /tmp/empty-dir, useful e.g.
   iter=0
   for node in ${_CUDA_NODE_LIST[@]}
   do
-    ${_SSH_BIN} ${_SSH_PARAMS} ${_CUDA_USERNAME_LIST[iter]}@${_CUDA_NODE_LIST[iter]} ${_EMPTY_DIR_COMMAND}
+    ${_SSH_BIN} ${_SSH_PARAMS} ${_CUDA_USERNAME_LIST[iter]}@${_CUDA_NODE_LIST[iter]} "${_MAKE_EMPTY_DIR_COMMAND} ; ${_REMOVE_EMPTY_DIR_CONTENT}"
     iter=$((iter+1))
   done
 }

--- a/scripts/appsAway_startApp.sh
+++ b/scripts/appsAway_startApp.sh
@@ -309,13 +309,13 @@ run_hardware_steps_via_ssh()
     myXauth="/run/user/$UID/gdm/Xauthority"
   fi
   
- if [ "$APPSAWAY_CONSOLENODE_ADDR" != "" ]; then
+  if [ "$APPSAWAY_CONSOLENODE_ADDR" != "" ]; then
     scp_to_node ${_CWD}/appsAway_containerPermissions.sh $APPSAWAY_CONSOLENODE_USERNAME $APPSAWAY_CONSOLENODE_ADDR $APPSAWAY_APP_PATH_NOT_CONSOLE
     scp_to_node ${_CWD}/appsAway_changeNewFilesPermissions.sh $APPSAWAY_CONSOLENODE_USERNAME $APPSAWAY_CONSOLENODE_ADDR $APPSAWAY_APP_PATH_NOT_CONSOLE 
     scp_to_node ${_CWD}/appsAway_getVolumesFileList.sh $APPSAWAY_CONSOLENODE_USERNAME $APPSAWAY_CONSOLENODE_ADDR $APPSAWAY_APP_PATH_NOT_CONSOLE       
-    run_via_ssh $APPSAWAY_CONSOLENODE_USERNAME $APPSAWAY_CONSOLENODE_ADDR "mkdir /tmp/empty-dir 2>/dev/null; export APPSAWAY_OPTIONS=${APPSAWAY_OPTIONS} ; export _YAML_VOLUMES_HOST=\"${_YAML_VOLUMES_HOST}\" ; export APPSAWAY_APP_PATH_NOT_CONSOLE=${APPSAWAY_APP_PATH_NOT_CONSOLE} ; ${_OS_HOME_DIR}/${APPSAWAY_CONSOLENODE_USERNAME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/appsAway_getVolumesFileList.sh"  
- fi
- ( if [ "$APPSAWAY_ICUBHEADNODE_ADDR" != "" ]; then
+    run_via_ssh $APPSAWAY_CONSOLENODE_USERNAME $APPSAWAY_CONSOLENODE_ADDR "export APPSAWAY_OPTIONS=${APPSAWAY_OPTIONS} ; export _YAML_VOLUMES_HOST=\"${_YAML_VOLUMES_HOST}\" ; export APPSAWAY_APP_PATH_NOT_CONSOLE=${APPSAWAY_APP_PATH_NOT_CONSOLE} ; ${_OS_HOME_DIR}/${APPSAWAY_CONSOLENODE_USERNAME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/appsAway_getVolumesFileList.sh"  
+  fi 
+  ( if [ "$APPSAWAY_ICUBHEADNODE_ADDR" != "" ]; then
     for file in ${APPSAWAY_HEAD_YAML_FILE_LIST}
     do
       log "running ${_DOCKER_COMPOSE_BIN_HEAD} with file ${_OS_HOME_DIR}/${APPSAWAY_ICUBHEADNODE_USERNAME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/${file} on host $APPSAWAY_ICUBHEADNODE_ADDR"
@@ -329,9 +329,9 @@ run_hardware_steps_via_ssh()
         _DOCKER_PULL="${_DOCKER_COMPOSE_BIN_HEAD} -f ${file} pull"
       else
         _DOCKER_PULL="true"
-      fi     
-      run_via_ssh $APPSAWAY_ICUBHEADNODE_USERNAME $APPSAWAY_ICUBHEADNODE_ADDR "mkdir /tmp/empty-dir 2>/dev/null; export APPSAWAY_OPTIONS=${APPSAWAY_OPTIONS} ; export _YAML_VOLUMES_HOST=\"${_YAML_VOLUMES_HOST}\" ; export APPSAWAY_APP_PATH_NOT_CONSOLE=${APPSAWAY_APP_PATH_NOT_CONSOLE} ; ${_OS_HOME_DIR}/${APPSAWAY_CONSOLENODE_USERNAME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/appsAway_getVolumesFileList.sh ; ${_DOCKER_PULL} ; ${_DOCKER_COMPOSE_BIN_HEAD} -f ${file} up --detach"
-    done
+      fi
+      run_via_ssh $APPSAWAY_ICUBHEADNODE_USERNAME $APPSAWAY_ICUBHEADNODE_ADDR "export APPSAWAY_OPTIONS=${APPSAWAY_OPTIONS} ; export _YAML_VOLUMES_HOST=\"${_YAML_VOLUMES_HOST}\" ; export APPSAWAY_APP_PATH_NOT_CONSOLE=${APPSAWAY_APP_PATH_NOT_CONSOLE} ; ${_OS_HOME_DIR}/${APPSAWAY_CONSOLENODE_USERNAME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/appsAway_getVolumesFileList.sh ; ${_DOCKER_PULL} ; ${_DOCKER_COMPOSE_BIN_HEAD} -f ${file} up --detach"
+    done 
   fi ) &
   val1=$(( $val1 + 5 ))
   echo $val1 >| ${HOME}/teamcode/appsAway/scripts/PIPE
@@ -352,8 +352,8 @@ run_hardware_steps_via_ssh()
       else
         _DOCKER_PULL="true"
       fi  
-      run_via_ssh $APPSAWAY_GUINODE_USERNAME $APPSAWAY_GUINODE_ADDR "mkdir /tmp/empty-dir 2>/dev/null; export APPSAWAY_OPTIONS=${APPSAWAY_OPTIONS} ; export DISPLAY=${GUI_DISPLAY} ; export XAUTHORITY=${GUI_XAUTHORITY}; export _YAML_VOLUMES_HOST=\"${_YAML_VOLUMES_HOST}\" ; export APPSAWAY_APP_PATH_NOT_CONSOLE=${APPSAWAY_APP_PATH_NOT_CONSOLE} ; ${_OS_HOME_DIR}/${APPSAWAY_GUINODE_USERNAME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/appsAway_getVolumesFileList.sh ; if [ -f '$file' ]; then ${_DOCKER_PULL}; ${_DOCKER_COMPOSE_BIN_GUI} -f ${file} up --detach; fi"
-    done
+      run_via_ssh $APPSAWAY_GUINODE_USERNAME $APPSAWAY_GUINODE_ADDR "export APPSAWAY_OPTIONS=${APPSAWAY_OPTIONS} ; export DISPLAY=${GUI_DISPLAY} ; export XAUTHORITY=${GUI_XAUTHORITY}; export _YAML_VOLUMES_HOST=\"${_YAML_VOLUMES_HOST}\" ; export APPSAWAY_APP_PATH_NOT_CONSOLE=${APPSAWAY_APP_PATH_NOT_CONSOLE} ; ${_OS_HOME_DIR}/${APPSAWAY_GUINODE_USERNAME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/appsAway_getVolumesFileList.sh ; if [ -f '$file' ]; then ${_DOCKER_PULL}; ${_DOCKER_COMPOSE_BIN_GUI} -f ${file} up --detach; fi"
+    done 
   elif [ "$APPSAWAY_GUINODE_ADDR" == "" ] && [ "$APPSAWAY_CONSOLENODE_ADDR" != "" ]; then
     for file in ${APPSAWAY_GUI_YAML_FILE_LIST}
     do
@@ -369,8 +369,8 @@ run_hardware_steps_via_ssh()
       else
         _DOCKER_PULL="true"
       fi  
-      run_via_ssh $APPSAWAY_CONSOLENODE_USERNAME $APPSAWAY_CONSOLENODE_ADDR "mkdir /tmp/empty-dir 2>/dev/null; export APPSAWAY_OPTIONS=${APPSAWAY_OPTIONS} ; export DISPLAY=${mydisplay} ; export XAUTHORITY=${myXauth};  export _YAML_VOLUMES_HOST=\"${_YAML_VOLUMES_HOST}\" ; export APPSAWAY_APP_PATH_NOT_CONSOLE=${APPSAWAY_APP_PATH_NOT_CONSOLE} ; ${_OS_HOME_DIR}/${APPSAWAY_CONSOLENODE_USERNAME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/appsAway_getVolumesFileList.sh ; if [ -f '$file' ]; then ${_DOCKER_PULL} ; ${_DOCKER_COMPOSE_BIN_CONSOLE} -f ${file} up --detach; fi"
-    done
+      run_via_ssh $APPSAWAY_CONSOLENODE_USERNAME $APPSAWAY_CONSOLENODE_ADDR "export APPSAWAY_OPTIONS=${APPSAWAY_OPTIONS} ; export DISPLAY=${mydisplay} ; export XAUTHORITY=${myXauth};  export _YAML_VOLUMES_HOST=\"${_YAML_VOLUMES_HOST}\" ; export APPSAWAY_APP_PATH_NOT_CONSOLE=${APPSAWAY_APP_PATH_NOT_CONSOLE} ; ${_OS_HOME_DIR}/${APPSAWAY_CONSOLENODE_USERNAME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/appsAway_getVolumesFileList.sh ; if [ -f '$file' ]; then ${_DOCKER_PULL} ; ${_DOCKER_COMPOSE_BIN_CONSOLE} -f ${file} up --detach; fi"
+    done 
   fi ) &
   val1=$(( $val1 + 10 ))
   echo $val1 >| ${HOME}/teamcode/appsAway/scripts/PIPE

--- a/scripts/appsAway_startApp.sh
+++ b/scripts/appsAway_startApp.sh
@@ -189,7 +189,7 @@ init()
       get_shared_volumes ${APPSAWAY_APP_PATH}/${file}
    done
  fi
- _YAML_VOLUMES_HOST=$(eval echo -e \"$_YAML_VOLUMES_HOST\")
+ _YAML_VOLUMES_HOST=$(eval echo -e \"$_YAML_VOLUMES_HOST\" || echo \"\")
  _SSH_CMD_PREFIX="cd ${APPSAWAY_APP_PATH} "
 }
 
@@ -313,7 +313,7 @@ run_hardware_steps_via_ssh()
     scp_to_node ${_CWD}/appsAway_containerPermissions.sh $APPSAWAY_CONSOLENODE_USERNAME $APPSAWAY_CONSOLENODE_ADDR $APPSAWAY_APP_PATH_NOT_CONSOLE
     scp_to_node ${_CWD}/appsAway_changeNewFilesPermissions.sh $APPSAWAY_CONSOLENODE_USERNAME $APPSAWAY_CONSOLENODE_ADDR $APPSAWAY_APP_PATH_NOT_CONSOLE 
     scp_to_node ${_CWD}/appsAway_getVolumesFileList.sh $APPSAWAY_CONSOLENODE_USERNAME $APPSAWAY_CONSOLENODE_ADDR $APPSAWAY_APP_PATH_NOT_CONSOLE       
-    run_via_ssh $APPSAWAY_CONSOLENODE_USERNAME $APPSAWAY_CONSOLENODE_ADDR "export APPSAWAY_OPTIONS=${APPSAWAY_OPTIONS} ; export _YAML_VOLUMES_HOST=\"${_YAML_VOLUMES_HOST}\" ; export APPSAWAY_APP_PATH_NOT_CONSOLE=${APPSAWAY_APP_PATH_NOT_CONSOLE} ; ${_OS_HOME_DIR}/${APPSAWAY_CONSOLENODE_USERNAME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/appsAway_getVolumesFileList.sh"  
+    run_via_ssh $APPSAWAY_CONSOLENODE_USERNAME $APPSAWAY_CONSOLENODE_ADDR "mkdir /tmp/empty-dir 2>/dev/null; export APPSAWAY_OPTIONS=${APPSAWAY_OPTIONS} ; export _YAML_VOLUMES_HOST=\"${_YAML_VOLUMES_HOST}\" ; export APPSAWAY_APP_PATH_NOT_CONSOLE=${APPSAWAY_APP_PATH_NOT_CONSOLE} ; ${_OS_HOME_DIR}/${APPSAWAY_CONSOLENODE_USERNAME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/appsAway_getVolumesFileList.sh"  
  fi
  ( if [ "$APPSAWAY_ICUBHEADNODE_ADDR" != "" ]; then
     for file in ${APPSAWAY_HEAD_YAML_FILE_LIST}
@@ -330,7 +330,7 @@ run_hardware_steps_via_ssh()
       else
         _DOCKER_PULL="true"
       fi     
-      run_via_ssh $APPSAWAY_ICUBHEADNODE_USERNAME $APPSAWAY_ICUBHEADNODE_ADDR "export APPSAWAY_OPTIONS=${APPSAWAY_OPTIONS} ; export _YAML_VOLUMES_HOST=\"${_YAML_VOLUMES_HOST}\" ; export APPSAWAY_APP_PATH_NOT_CONSOLE=${APPSAWAY_APP_PATH_NOT_CONSOLE} ; ${_OS_HOME_DIR}/${APPSAWAY_CONSOLENODE_USERNAME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/appsAway_getVolumesFileList.sh ; ${_DOCKER_PULL} ; ${_DOCKER_COMPOSE_BIN_HEAD} -f ${file} up --detach"
+      run_via_ssh $APPSAWAY_ICUBHEADNODE_USERNAME $APPSAWAY_ICUBHEADNODE_ADDR "mkdir /tmp/empty-dir 2>/dev/null; export APPSAWAY_OPTIONS=${APPSAWAY_OPTIONS} ; export _YAML_VOLUMES_HOST=\"${_YAML_VOLUMES_HOST}\" ; export APPSAWAY_APP_PATH_NOT_CONSOLE=${APPSAWAY_APP_PATH_NOT_CONSOLE} ; ${_OS_HOME_DIR}/${APPSAWAY_CONSOLENODE_USERNAME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/appsAway_getVolumesFileList.sh ; ${_DOCKER_PULL} ; ${_DOCKER_COMPOSE_BIN_HEAD} -f ${file} up --detach"
     done
   fi ) &
   val1=$(( $val1 + 5 ))
@@ -352,7 +352,7 @@ run_hardware_steps_via_ssh()
       else
         _DOCKER_PULL="true"
       fi  
-      run_via_ssh $APPSAWAY_GUINODE_USERNAME $APPSAWAY_GUINODE_ADDR "export APPSAWAY_OPTIONS=${APPSAWAY_OPTIONS} ; export DISPLAY=${GUI_DISPLAY} ; export XAUTHORITY=${GUI_XAUTHORITY}; export _YAML_VOLUMES_HOST=\"${_YAML_VOLUMES_HOST}\" ; export APPSAWAY_APP_PATH_NOT_CONSOLE=${APPSAWAY_APP_PATH_NOT_CONSOLE} ; ${_OS_HOME_DIR}/${APPSAWAY_GUINODE_USERNAME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/appsAway_getVolumesFileList.sh ; if [ -f '$file' ]; then ${_DOCKER_PULL}; ${_DOCKER_COMPOSE_BIN_GUI} -f ${file} up --detach; fi"
+      run_via_ssh $APPSAWAY_GUINODE_USERNAME $APPSAWAY_GUINODE_ADDR "mkdir /tmp/empty-dir 2>/dev/null; export APPSAWAY_OPTIONS=${APPSAWAY_OPTIONS} ; export DISPLAY=${GUI_DISPLAY} ; export XAUTHORITY=${GUI_XAUTHORITY}; export _YAML_VOLUMES_HOST=\"${_YAML_VOLUMES_HOST}\" ; export APPSAWAY_APP_PATH_NOT_CONSOLE=${APPSAWAY_APP_PATH_NOT_CONSOLE} ; ${_OS_HOME_DIR}/${APPSAWAY_GUINODE_USERNAME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/appsAway_getVolumesFileList.sh ; if [ -f '$file' ]; then ${_DOCKER_PULL}; ${_DOCKER_COMPOSE_BIN_GUI} -f ${file} up --detach; fi"
     done
   elif [ "$APPSAWAY_GUINODE_ADDR" == "" ] && [ "$APPSAWAY_CONSOLENODE_ADDR" != "" ]; then
     for file in ${APPSAWAY_GUI_YAML_FILE_LIST}
@@ -369,7 +369,7 @@ run_hardware_steps_via_ssh()
       else
         _DOCKER_PULL="true"
       fi  
-      run_via_ssh $APPSAWAY_CONSOLENODE_USERNAME $APPSAWAY_CONSOLENODE_ADDR "export APPSAWAY_OPTIONS=${APPSAWAY_OPTIONS} ; export DISPLAY=${mydisplay} ; export XAUTHORITY=${myXauth};  export _YAML_VOLUMES_HOST=\"${_YAML_VOLUMES_HOST}\" ; export APPSAWAY_APP_PATH_NOT_CONSOLE=${APPSAWAY_APP_PATH_NOT_CONSOLE} ; ${_OS_HOME_DIR}/${APPSAWAY_CONSOLENODE_USERNAME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/appsAway_getVolumesFileList.sh ; if [ -f '$file' ]; then ${_DOCKER_PULL} ; ${_DOCKER_COMPOSE_BIN_CONSOLE} -f ${file} up --detach; fi"
+      run_via_ssh $APPSAWAY_CONSOLENODE_USERNAME $APPSAWAY_CONSOLENODE_ADDR "mkdir /tmp/empty-dir 2>/dev/null; export APPSAWAY_OPTIONS=${APPSAWAY_OPTIONS} ; export DISPLAY=${mydisplay} ; export XAUTHORITY=${myXauth};  export _YAML_VOLUMES_HOST=\"${_YAML_VOLUMES_HOST}\" ; export APPSAWAY_APP_PATH_NOT_CONSOLE=${APPSAWAY_APP_PATH_NOT_CONSOLE} ; ${_OS_HOME_DIR}/${APPSAWAY_CONSOLENODE_USERNAME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/appsAway_getVolumesFileList.sh ; if [ -f '$file' ]; then ${_DOCKER_PULL} ; ${_DOCKER_COMPOSE_BIN_CONSOLE} -f ${file} up --detach; fi"
     done
   fi ) &
   val1=$(( $val1 + 10 ))


### PR DESCRIPTION
Currently, if you launch the `funnyThingsApp` deployment without specifying a path for import/export the container hosting the funny things GUI fails to open.

This is unexpected behavior since the user may be interested in testing the functionality of funny things without necessarily wanting to import or export files.

This PR addresses this by creating an empty directory in `/tmp` and sharing this volume with the container if no other path is specified.