### PR TITLE
Remove parameters from speech ymls

### DIFF
--- a/demos/googleDialog/composeGui.yml
+++ b/demos/googleDialog/composeGui.yml
@@ -37,7 +37,7 @@ services:
     <<: *yarp-base
     devices: 
       - "/dev/snd:/dev/snd"
-    command: sh -c "if [ -f "/root/.config/yarp/yarp_namespace.conf" ]; then yarp wait $$(echo $$(cat /root/.config/yarp/yarp_namespace.conf)); else yarp wait /root; fi; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --rate 16000 --samples 16000"
+    command: sh -c "if [ -f "/root/.config/yarp/yarp_namespace.conf" ]; then yarp wait $$(echo $$(cat /root/.config/yarp/yarp_namespace.conf)); else yarp wait /root; fi; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --AUDIO_BASE::channels 1 --rate 16000 --AUDIO_BASE::rate 16000 --samples 16000 --AUDIO_BASE::samples 16000"
 
   yDemoGoogleSynthesis:
     <<: *yarp-base

--- a/demos/googleDialog/composeGui.yml
+++ b/demos/googleDialog/composeGui.yml
@@ -37,7 +37,7 @@ services:
     <<: *yarp-base
     devices: 
       - "/dev/snd:/dev/snd"
-    command: sh -c "if [ -f "/root/.config/yarp/yarp_namespace.conf" ]; then yarp wait $$(echo $$(cat /root/.config/yarp/yarp_namespace.conf)); else yarp wait /root; fi; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --AUDIO_BASE::channels 1 --rate 16000 --AUDIO_BASE::rate 16000 --samples 16000 --AUDIO_BASE::samples 16000"
+    command: sh -c "if [ -f "/root/.config/yarp/yarp_namespace.conf" ]; then yarp wait $$(echo $$(cat /root/.config/yarp/yarp_namespace.conf)); else yarp wait /root; fi; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini"
 
   yDemoGoogleSynthesis:
     <<: *yarp-base

--- a/demos/googleSpeechApp/composeGui.yml
+++ b/demos/googleSpeechApp/composeGui.yml
@@ -37,7 +37,7 @@ services:
     <<: *yarp-base
     devices: 
       - "/dev/snd:/dev/snd"
-    command: sh -c "if [ ${GOOGLE_INPUT} = 'True' ]; then if [ -f "/root/.config/yarp/yarp_namespace.conf" ]; then yarp wait $$(echo $$(cat /root/.config/yarp/yarp_namespace.conf)); else yarp wait /root; fi; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --rate 16000 --samples 16000; fi;"
+    command: sh -c "if [ ${GOOGLE_INPUT} = 'True' ]; then if [ -f "/root/.config/yarp/yarp_namespace.conf" ]; then yarp wait $$(echo $$(cat /root/.config/yarp/yarp_namespace.conf)); else yarp wait /root; fi; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --AUDIO_BASE::channels 1 --rate 16000 --AUDIO_BASE::rate 16000 --samples 16000 --AUDIO_BASE::samples 16000; fi;"
 
   yDemoGoogleSynthesis:
     <<: *yarp-base

--- a/demos/googleSpeechApp/composeGui.yml
+++ b/demos/googleSpeechApp/composeGui.yml
@@ -37,7 +37,7 @@ services:
     <<: *yarp-base
     devices: 
       - "/dev/snd:/dev/snd"
-    command: sh -c "if [ ${GOOGLE_INPUT} = 'True' ]; then if [ -f "/root/.config/yarp/yarp_namespace.conf" ]; then yarp wait $$(echo $$(cat /root/.config/yarp/yarp_namespace.conf)); else yarp wait /root; fi; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --AUDIO_BASE::channels 1 --rate 16000 --AUDIO_BASE::rate 16000 --samples 16000 --AUDIO_BASE::samples 16000; fi;"
+    command: sh -c "if [ ${GOOGLE_INPUT} = 'True' ]; then if [ -f "/root/.config/yarp/yarp_namespace.conf" ]; then yarp wait $$(echo $$(cat /root/.config/yarp/yarp_namespace.conf)); else yarp wait /root; fi; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini; fi;"
 
   yDemoGoogleSynthesis:
     <<: *yarp-base

--- a/demos/googleSpeechProcessing/composeGui.yml
+++ b/demos/googleSpeechProcessing/composeGui.yml
@@ -31,7 +31,7 @@ services:
     <<: *yarp-base
     devices: 
       - "/dev/snd:/dev/snd"
-    command: sh -c "if [ -f "/root/.config/yarp/yarp_namespace.conf" ]; then yarp wait $$(echo $$(cat /root/.config/yarp/yarp_namespace.conf)); else yarp wait /root; fi; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --AUDIO_BASE::channels 1 --rate 16000 --AUDIO_BASE::rate 16000 --samples 16000 --AUDIO_BASE::samples 16000"
+    command: sh -c "if [ -f "/root/.config/yarp/yarp_namespace.conf" ]; then yarp wait $$(echo $$(cat /root/.config/yarp/yarp_namespace.conf)); else yarp wait /root; fi; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini"
   
   yconnect_audio:
     <<: *yarp-base

--- a/demos/googleSpeechProcessing/composeGui.yml
+++ b/demos/googleSpeechProcessing/composeGui.yml
@@ -31,7 +31,7 @@ services:
     <<: *yarp-base
     devices: 
       - "/dev/snd:/dev/snd"
-    command: sh -c "if [ -f "/root/.config/yarp/yarp_namespace.conf" ]; then yarp wait $$(echo $$(cat /root/.config/yarp/yarp_namespace.conf)); else yarp wait /root; fi; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --rate 16000 --samples 16000"
+    command: sh -c "if [ -f "/root/.config/yarp/yarp_namespace.conf" ]; then yarp wait $$(echo $$(cat /root/.config/yarp/yarp_namespace.conf)); else yarp wait /root; fi; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --AUDIO_BASE::channels 1 --rate 16000 --AUDIO_BASE::rate 16000 --samples 16000 --AUDIO_BASE::samples 16000"
   
   yconnect_audio:
     <<: *yarp-base

--- a/demos/speechToSpeech/composeGui.yml
+++ b/demos/speechToSpeech/composeGui.yml
@@ -33,7 +33,7 @@ services:
     <<: *yarp-base
     devices: 
       - "/dev/snd:/dev/snd"
-    command: sh -c "yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --AUDIO_BASE::channels 1 --rate 16000 --AUDIO_BASE::rate 16000 --samples 16000 --AUDIO_BASE::samples 16000"
+    command: sh -c "yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini"
   
   yconnect_audio:
     <<: *yarp-base

--- a/demos/speechToSpeech/composeGui.yml
+++ b/demos/speechToSpeech/composeGui.yml
@@ -33,7 +33,7 @@ services:
     <<: *yarp-base
     devices: 
       - "/dev/snd:/dev/snd"
-    command: sh -c "yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --rate 16000 --samples 16000"
+    command: sh -c "yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --AUDIO_BASE::channels 1 --rate 16000 --AUDIO_BASE::rate 16000 --samples 16000 --AUDIO_BASE::samples 16000"
   
   yconnect_audio:
     <<: *yarp-base

--- a/demos/speechToText/composeGui.yml
+++ b/demos/speechToText/composeGui.yml
@@ -31,7 +31,7 @@ services:
     <<: *yarp-base
     devices: 
       - "/dev/snd:/dev/snd"
-    command: sh -c "if [ -f "/root/.config/yarp/yarp_namespace.conf" ]; then yarp wait $$(echo $$(cat /root/.config/yarp/yarp_namespace.conf)); else yarp wait /root; fi; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --AUDIO_BASE::channels 1 --rate 16000 --AUDIO_BASE::rate 16000 --samples 16000 --AUDIO_BASE::samples 16000"
+    command: sh -c "if [ -f "/root/.config/yarp/yarp_namespace.conf" ]; then yarp wait $$(echo $$(cat /root/.config/yarp/yarp_namespace.conf)); else yarp wait /root; fi; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini"
   
   yconnect_audio:
     <<: *yarp-base

--- a/demos/speechToText/composeGui.yml
+++ b/demos/speechToText/composeGui.yml
@@ -31,7 +31,7 @@ services:
     <<: *yarp-base
     devices: 
       - "/dev/snd:/dev/snd"
-    command: sh -c "if [ -f "/root/.config/yarp/yarp_namespace.conf" ]; then yarp wait $$(echo $$(cat /root/.config/yarp/yarp_namespace.conf)); else yarp wait /root; fi; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --rate 16000 --samples 16000"
+    command: sh -c "if [ -f "/root/.config/yarp/yarp_namespace.conf" ]; then yarp wait $$(echo $$(cat /root/.config/yarp/yarp_namespace.conf)); else yarp wait /root; fi; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --AUDIO_BASE::channels 1 --rate 16000 --AUDIO_BASE::rate 16000 --samples 16000 --AUDIO_BASE::samples 16000"
   
   yconnect_audio:
     <<: *yarp-base

--- a/demos/startQA/composeGui.yml
+++ b/demos/startQA/composeGui.yml
@@ -32,7 +32,7 @@ services:
     <<: *yarp-base
     devices: 
       - "/dev/snd:/dev/snd"
-    command: sh -c "if [ -f "/root/.config/yarp/yarp_namespace.conf" ]; then yarp wait $$(echo $$(cat /root/.config/yarp/yarp_namespace.conf)); else yarp wait /root; fi; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --AUDIO_BASE::channels 1 --rate 16000 --AUDIO_BASE::rate 16000 --samples 16000 --AUDIO_BASE::samples 16000"
+    command: sh -c "if [ -f "/root/.config/yarp/yarp_namespace.conf" ]; then yarp wait $$(echo $$(cat /root/.config/yarp/yarp_namespace.conf)); else yarp wait /root; fi; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini"
   
   yconnect_audio:
     <<: *yarp-base

--- a/demos/startQA/composeGui.yml
+++ b/demos/startQA/composeGui.yml
@@ -32,7 +32,7 @@ services:
     <<: *yarp-base
     devices: 
       - "/dev/snd:/dev/snd"
-    command: sh -c "if [ -f "/root/.config/yarp/yarp_namespace.conf" ]; then yarp wait $$(echo $$(cat /root/.config/yarp/yarp_namespace.conf)); else yarp wait /root; fi; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --rate 16000 --samples 16000"
+    command: sh -c "if [ -f "/root/.config/yarp/yarp_namespace.conf" ]; then yarp wait $$(echo $$(cat /root/.config/yarp/yarp_namespace.conf)); else yarp wait /root; fi; yarpdev --device AudioRecorderWrapper --from /root/startaudio.ini --channels 1  --AUDIO_BASE::channels 1 --rate 16000 --AUDIO_BASE::rate 16000 --samples 16000 --AUDIO_BASE::samples 16000"
   
   yconnect_audio:
     <<: *yarp-base


### PR DESCRIPTION
This PR modifies the calls to the microphone yarpdev to remove flag parameters like `--channels` and `--rate`. These parameters will now be part of the images themselves in the form of config files.