### PR TITLE
Removed cuda volumes in graspTheBallGazebo and iCubGazeboGrasping

### DIFF
--- a/demos/graspTheBallGazebo/composeGui.yml
+++ b/demos/graspTheBallGazebo/composeGui.yml
@@ -16,11 +16,6 @@ x-yarp-gazebo: &yarp-gazebo
     - "${HOME}/teamcode/appsAway/demos/graspTheBallGazebo/gazebo/models/red-ball:/projects/iCubContrib/share/gazebo/models/red-ball"
     - "${HOME}/teamcode/appsAway/demos/graspTheBallGazebo/gazebo/worlds/grasp-ball-gazebo.sdf:/projects/iCubContrib/share/gazebo/worlds/grasp-ball-gazebo.sdf"
     - "${HOME}/teamcode/appsAway/demos/graspTheBallGazebo/gazebo/libdemoRedBall-world.so:/projects/iCubContrib/lib/libdemoRedBall-world.so"
-    - "/usr/local/cuda/lib64:/usr/lib/nvidia"
-    - "/usr/local/cuda:/usr/local/cuda"
-    - "/usr/lib/x86_64-linux-gnu:/usr/lib/projects/x86_64-linux-gnu"
-    - "/usr/bin:/usr/projects/bin"
-    - "/dev/dri:/dev/dri"
   ports:
     - "10000:10000"
   network_mode: "host"

--- a/demos/iCubGazeboGrasping/composeGui.yml
+++ b/demos/iCubGazeboGrasping/composeGui.yml
@@ -13,11 +13,6 @@ x-yarp-base: &yarp-base
     - "/tmp/.X11-unix:/tmp/.X11-unix"
     - "${XAUTHORITY}:/root/.Xauthority"
     - "${HOME}/${YARP_CONF_PATH}:/root/.config/yarp"
-    - "/usr/local/cuda/lib64:/usr/lib/nvidia"
-    - "/usr/local/cuda:/usr/local/cuda"
-    - "/usr/lib/x86_64-linux-gnu:/usr/lib/projects/x86_64-linux-gnu"
-    - "/usr/bin:/usr/projects/bin"
-    - "/dev/dri:/dev/dri"
   ports:
     - "10000:10000"
   network_mode: "host"


### PR DESCRIPTION
This PR removes the sharing of `cuda` volumes, which make `graspTheBallGazebo` and `iCubGazeboGrasping` fail on systems where `cuda` is detected (probably we overwrite some libraries when sharing these folders).
This works on systems with and without `cuda`.
