### PR TITLE
Share Google Key file to other machines in cluster

### DIFF
--- a/demos/funnyThingsApp/composeGui.yml
+++ b/demos/funnyThingsApp/composeGui.yml
@@ -24,14 +24,14 @@ x-yarp-speech: &yarp-speech
     - PULSE_SERVER=unix:${XDG_RUNTIME_DIR}/pulse/native
     - YARP_FORWARD_LOG_ENABLE=1
     - YARP_ROBOT_NAME
-    - FILE_INPUT
+    - FILE_INPUT=${KEY_FILE}
     - LANGUAGE_SYNTHESIS_INPUT
     - VOICE_NAME_INPUT
   volumes:
     - "/tmp/.X11-unix:/tmp/.X11-unix"
     - "${XAUTHORITY}:/root/.Xauthority"
     - "${HOME}/${YARP_CONF_PATH}:/root/.config/yarp"
-    - "${FILE_INPUT_PATH}:/root/authorization"
+    - "${HOME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/key_folder:/root/authorization"
     - "${XDG_RUNTIME_DIR}/pulse/native:${XDG_RUNTIME_DIR}/pulse/native"
     - "~/.config/pulse/cookie:/root/.config/pulse/cookie"
     - "/dev:/dev"

--- a/demos/funnyThingsApp/gui/gui_conf.ini
+++ b/demos/funnyThingsApp/gui/gui_conf.ini
@@ -12,7 +12,7 @@ audioInput "" "Try your voice!" AUDIO_INPUT ${HOME}/teamcode/appsAway/demos/funn
 textEditBox "Path for import/export of files:" "" FILE_IMPORT_EXPORT_PATH None on None
 
 [Button hierarchy]
-Dependency - START_BUTTON - ( {FILE_INPUT selected enable} )
+Dependency - START_BUTTON - ( {KEY_FILE selected enable} )
 
 [Button Options]
 OptionList - VOICE_NAME_INPUT - LANGUAGE_SYNTHESIS_INPUT [en-US/fr-FR/en-GB/pt-PT/it-IT] [[en-US-Wavenet-A/en-US-Wavenet-B/en-US-Wavenet-C/en-US-Wavenet-D/en-US-Wavenet-E/en-US-Wavenet-F/en-US-Wavenet-G/en-US-Wavenet-H/en-US-Wavenet-I/en-US-Wavenet-J],[fr-FR-Wavenet-A/fr-FR-Wavenet-B/fr-FR-Wavenet-C/fr-FR-Wavenet-D],[en-GB-Wavenet-A/en-GB-Wavenet-B/en-GB-Wavenet-C/en-GB-Wavenet-D],[pt-PT-Wavenet-A/pt-PT-Wavenet-B/pt-PT-Wavenet-C/pt-PT-Wavenet-D],[it-IT-Wavenet-A/it-IT-Wavenet-B/it-IT-Wavenet-C/it-IT-Wavenet-D]]

--- a/demos/funnyThingsApp/gui/gui_conf.ini
+++ b/demos/funnyThingsApp/gui/gui_conf.ini
@@ -5,7 +5,7 @@ title "Funny Things App"
 ImageName "images/icub-funny-things.jpg"
  
 [right options]
-fileInput "Google key json file (required):" "Choose a file" FILE_INPUT None on None
+fileInput "Google key json file (required):" "Choose a file" KEY_FILE None on None
 dropdownList "Language of the speech:" "" LANGUAGE_SYNTHESIS_INPUT en-US/it-IT/pt-PT/fr-FR/en-GB on None
 dropdownList "Voice types" "" VOICE_NAME_INPUT en-US-Wavenet-A/en-US-Wavenet-B/en-US-Wavenet-C/en-US-Wavenet-D/en-US-Wavenet-E/en-US-Wavenet-F/en-US-Wavenet-G/en-US-Wavenet-H/en-US-Wavenet-I/en-US-Wavenet-J on None
 audioInput "" "Try your voice!" AUDIO_INPUT ${HOME}/teamcode/appsAway/demos/funnyThingsApp/gui/images/audioicon.png on None

--- a/demos/googleDialog/composeGui.yml
+++ b/demos/googleDialog/composeGui.yml
@@ -9,7 +9,7 @@ x-yarp-base: &yarp-base
     - PULSE_SERVER=unix:${XDG_RUNTIME_DIR}/pulse/native
     - YARP_FORWARD_LOG_ENABLE=1
     - YARP_ROBOT_NAME
-    - FILE_INPUT
+    - FILE_INPUT=${KEY_FILE}
     - GOOGLE_SYNTHESIS_INPUT
     - LANGUAGE_SYNTHESIS_INPUT
     - VOICE_NAME_INPUT
@@ -18,7 +18,7 @@ x-yarp-base: &yarp-base
     - "/tmp/.X11-unix:/tmp/.X11-unix"
     - "${XAUTHORITY}:/root/.Xauthority"
     - "${HOME}/${YARP_CONF_PATH}:/root/.config/yarp"
-    - "${FILE_INPUT_PATH}:/root/authorization"
+    - "${HOME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/key_folder:/root/authorization"
     - "${XDG_RUNTIME_DIR}/pulse/native:${XDG_RUNTIME_DIR}/pulse/native"
     - "~/.config/pulse/cookie:/root/.config/pulse/cookie"
     - "/dev:/dev"

--- a/demos/googleDialog/gui/gui_conf.ini
+++ b/demos/googleDialog/gui/gui_conf.ini
@@ -5,8 +5,7 @@ title "Google Dialog"
 ImageName "images/googledialogflow_medium.png"
  
 [right options]
-fileInput "" "Choose a file" FILE_INPUT None on None
-textEditBox "Insert the name of your agent:" "" INPUT_BOX None on None
+fileInput "Google key json file (required):" "Choose a file" KEY_FILE None on NonetextEditBox "Insert the name of your agent:" "" INPUT_BOX None on None
 dropdownList "Language of the dialogflow:" "" LANGUAGE_SYNTHESIS_INPUT en-US/it-IT/pt-PT/fr-FR/en-GB on None
 toggleButton "" "Speech-to-text" GOOGLE_INPUT True/False on unticked
 toggleButton "" "Google dialog" GOOGLE_DIALOG_INPUT True/False off ticked

--- a/demos/googleDialog/gui/gui_conf.ini
+++ b/demos/googleDialog/gui/gui_conf.ini
@@ -5,7 +5,8 @@ title "Google Dialog"
 ImageName "images/googledialogflow_medium.png"
  
 [right options]
-fileInput "Google key json file (required):" "Choose a file" KEY_FILE None on NonetextEditBox "Insert the name of your agent:" "" INPUT_BOX None on None
+fileInput "Google key json file (required):" "Choose a file" KEY_FILE None on None
+textEditBox "Insert the name of your agent:" "" INPUT_BOX None on None
 dropdownList "Language of the dialogflow:" "" LANGUAGE_SYNTHESIS_INPUT en-US/it-IT/pt-PT/fr-FR/en-GB on None
 toggleButton "" "Speech-to-text" GOOGLE_INPUT True/False on unticked
 toggleButton "" "Google dialog" GOOGLE_DIALOG_INPUT True/False off ticked
@@ -16,7 +17,7 @@ audioInput "" "Try your voice!" AUDIO_INPUT ${HOME}/teamcode/appsAway/demos/goog
 [Button hierarchy]
 Dependency - VOICE_NAME_INPUT - ( {GOOGLE_SYNTHESIS_INPUT selected enable} ) 
 Dependency - AUDIO_INPUT - ( {GOOGLE_SYNTHESIS_INPUT selected enable} )
-Dependency - START_BUTTON - ( {FILE_INPUT selected enable} && {INPUT_BOX selected enable} )
+Dependency - START_BUTTON - ( {KEY_FILE selected enable} && {INPUT_BOX selected enable} )
 
 [Button Options]
 OptionList - VOICE_NAME_INPUT - LANGUAGE_SYNTHESIS_INPUT [en-US/fr-FR/en-GB/pt-PT/it-IT] [[en-US-Wavenet-A/en-US-Wavenet-B/en-US-Wavenet-C/en-US-Wavenet-D/en-US-Wavenet-E/en-US-Wavenet-F/en-US-Wavenet-G/en-US-Wavenet-H/en-US-Wavenet-I/en-US-Wavenet-J],[fr-FR-Wavenet-A/fr-FR-Wavenet-B/fr-FR-Wavenet-C/fr-FR-Wavenet-D],[en-GB-Wavenet-A/en-GB-Wavenet-B/en-GB-Wavenet-C/en-GB-Wavenet-D],[pt-PT-Wavenet-A/pt-PT-Wavenet-B/pt-PT-Wavenet-C/pt-PT-Wavenet-D],[it-IT-Wavenet-A/it-IT-Wavenet-B/it-IT-Wavenet-C/it-IT-Wavenet-D]]

--- a/demos/googleDialog/main.yml
+++ b/demos/googleDialog/main.yml
@@ -4,7 +4,7 @@ x-yarp-base: &yarp-base
   image: icubteamcode/speech:v2021.08.1-stable_master_sources
   environment:
     - YARP_FORWARD_LOG_ENABLE=1
-    - FILE_INPUT
+    - FILE_INPUT=${KEY_FILE}
     - INPUT_BOX
     - GOOGLE_INPUT
     - GOOGLE_SYNTHESIS_INPUT
@@ -12,7 +12,7 @@ x-yarp-base: &yarp-base
     - LANGUAGE_SYNTHESIS_INPUT
   volumes:
     - "${HOME}/${YARP_CONF_PATH}:/root/.config/yarp"
-    - "${FILE_INPUT_PATH}:/root/authorization"
+    - "${HOME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/key_folder:/root/authorization"
   networks:
     - hostnet
 

--- a/demos/googleSpeechApp/composeGui.yml
+++ b/demos/googleSpeechApp/composeGui.yml
@@ -9,7 +9,7 @@ x-yarp-base: &yarp-base
     - PULSE_SERVER=unix:${XDG_RUNTIME_DIR}/pulse/native
     - YARP_FORWARD_LOG_ENABLE=1
     - YARP_ROBOT_NAME
-    - FILE_INPUT
+    - FILE_INPUT=${KEY_FILE}
     - GOOGLE_SYNTHESIS_INPUT
     - LANGUAGE_SYNTHESIS_INPUT
     - VOICE_NAME_INPUT
@@ -18,7 +18,7 @@ x-yarp-base: &yarp-base
     - "/tmp/.X11-unix:/tmp/.X11-unix"
     - "${XAUTHORITY}:/root/.Xauthority"
     - "${HOME}/${YARP_CONF_PATH}:/root/.config/yarp"
-    - "${FILE_INPUT_PATH}:/root/authorization"
+    - "${HOME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/key_folder:/root/authorization"
     - "${XDG_RUNTIME_DIR}/pulse/native:${XDG_RUNTIME_DIR}/pulse/native"
     - "~/.config/pulse/cookie:/root/.config/pulse/cookie"
     - "/dev:/dev"

--- a/demos/googleSpeechApp/gui/gui_conf.ini
+++ b/demos/googleSpeechApp/gui/gui_conf.ini
@@ -5,8 +5,7 @@ title "Google Speech App"
 ImageName "images/Voice-Recognition-Google-Cloud-speech-to-text.png"
  
 [right options]
-fileInput "" "Select key json file (required)" FILE_INPUT None on None
-toggleButton "" "Speech-to-text" GOOGLE_INPUT True/False on unticked
+fileInput "Google key json file (required):" "Choose a file" KEY_FILE None on NonetoggleButton "" "Speech-to-text" GOOGLE_INPUT True/False on unticked
 dropdownList "Language of the speech-to-text:" "" LANGUAGE_INPUT en-US/it-IT/pt-PT/fr-FR/en-GB on None
 toggleButton "" "Google Processing" GOOGLE_PROCESSING True/False on unticked
 toggleButton "" "Text-to-speech" GOOGLE_SYNTHESIS_INPUT True/False on unticked

--- a/demos/googleSpeechApp/gui/gui_conf.ini
+++ b/demos/googleSpeechApp/gui/gui_conf.ini
@@ -5,7 +5,8 @@ title "Google Speech App"
 ImageName "images/Voice-Recognition-Google-Cloud-speech-to-text.png"
  
 [right options]
-fileInput "Google key json file (required):" "Choose a file" KEY_FILE None on NonetoggleButton "" "Speech-to-text" GOOGLE_INPUT True/False on unticked
+fileInput "Google key json file (required):" "Choose a file" KEY_FILE None on None
+toggleButton "" "Speech-to-text" GOOGLE_INPUT True/False on unticked
 dropdownList "Language of the speech-to-text:" "" LANGUAGE_INPUT en-US/it-IT/pt-PT/fr-FR/en-GB on None
 toggleButton "" "Google Processing" GOOGLE_PROCESSING True/False on unticked
 toggleButton "" "Text-to-speech" GOOGLE_SYNTHESIS_INPUT True/False on unticked
@@ -18,7 +19,7 @@ Dependency - LANGUAGE_INPUT - ( {GOOGLE_INPUT selected enable} )
 Dependency - LANGUAGE_SYNTHESIS_INPUT - ( {GOOGLE_SYNTHESIS_INPUT selected enable} )
 Dependency - VOICE_NAME_INPUT - ( {GOOGLE_SYNTHESIS_INPUT selected enable} ) 
 Dependency - AUDIO_INPUT - ( {GOOGLE_SYNTHESIS_INPUT selected enable} )
-Dependency - START_BUTTON - ( {FILE_INPUT selected enable} && ( {GOOGLE_INPUT selected enable} || {GOOGLE_PROCESSING selected enable} || {GOOGLE_SYNTHESIS_INPUT selected enable} ) )
+Dependency - START_BUTTON - ( {KEY_FILE selected enable} && ( {GOOGLE_INPUT selected enable} || {GOOGLE_PROCESSING selected enable} || {GOOGLE_SYNTHESIS_INPUT selected enable} ) )
 
 [Button Options]
 OptionList - VOICE_NAME_INPUT - LANGUAGE_SYNTHESIS_INPUT [en-US/fr-FR/en-GB/pt-PT/it-IT] [[en-US-Wavenet-A/en-US-Wavenet-B/en-US-Wavenet-C/en-US-Wavenet-D/en-US-Wavenet-E/en-US-Wavenet-F/en-US-Wavenet-G/en-US-Wavenet-H/en-US-Wavenet-I/en-US-Wavenet-J],[fr-FR-Wavenet-A/fr-FR-Wavenet-B/fr-FR-Wavenet-C/fr-FR-Wavenet-D],[en-GB-Wavenet-A/en-GB-Wavenet-B/en-GB-Wavenet-C/en-GB-Wavenet-D],[pt-PT-Wavenet-A/pt-PT-Wavenet-B/pt-PT-Wavenet-C/pt-PT-Wavenet-D],[it-IT-Wavenet-A/it-IT-Wavenet-B/it-IT-Wavenet-C/it-IT-Wavenet-D]]

--- a/demos/googleSpeechApp/main.yml
+++ b/demos/googleSpeechApp/main.yml
@@ -4,7 +4,7 @@ x-yarp-base: &yarp-base
   image: icubteamcode/speech:v2021.08.1-stable_master_sources
   environment:
     - YARP_FORWARD_LOG_ENABLE=1
-    - FILE_INPUT
+    - FILE_INPUT=${KEY_FILE}
     - INPUT_BOX
     - GOOGLE_INPUT
     - LANGUAGE_INPUT
@@ -14,7 +14,7 @@ x-yarp-base: &yarp-base
     - VOICE_NAME_INPUT
   volumes:
     - "${HOME}/${YARP_CONF_PATH}:/root/.config/yarp"
-    - "${FILE_INPUT_PATH}:/root/authorization"
+    - "${HOME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/key_folder:/root/authorization"
   networks:
     - hostnet
 

--- a/demos/googleSpeechProcessing/composeGui.yml
+++ b/demos/googleSpeechProcessing/composeGui.yml
@@ -8,14 +8,14 @@ x-yarp-base: &yarp-base
     - XAUTHORITY=/root/.Xauthority
     - YARP_FORWARD_LOG_ENABLE=1
     - YARP_ROBOT_NAME
-    - FILE_INPUT
+    - FILE_INPUT=${KEY_FILE}
     - PULSE_SERVER=unix:${XDG_RUNTIME_DIR}/pulse/native
     - XDG_RUNTIME_DIR
   volumes:
     - "/tmp/.X11-unix:/tmp/.X11-unix"
     - "${XAUTHORITY}:/root/.Xauthority"
     - "${HOME}/${YARP_CONF_PATH}:/root/.config/yarp"
-    - "${FILE_INPUT_PATH}:/root/authorization"
+    - "${HOME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/key_folder:/root/authorization"
     - "${XDG_RUNTIME_DIR}/pulse/native:${XDG_RUNTIME_DIR}/pulse/native"
     - "~/.config/pulse/cookie:/root/.config/pulse/cookie"
     - "/dev:/dev"

--- a/demos/googleSpeechProcessing/gui/gui_conf.ini
+++ b/demos/googleSpeechProcessing/gui/gui_conf.ini
@@ -12,4 +12,4 @@ dropdownList "Language of the speech:" "" LANGUAGE_SPEECH_INPUT en-US/it-IT/pt-P
 
 [Button hierarchy]
 Dependency - LANGUAGE_SPEECH_INPUT - ( {GOOGLE_INPUT selected enable} )
-Dependency - START_BUTTON - ( {FILE_INPUT selected enable} )
+Dependency - START_BUTTON - ( {KEY_FILE selected enable} )

--- a/demos/googleSpeechProcessing/gui/gui_conf.ini
+++ b/demos/googleSpeechProcessing/gui/gui_conf.ini
@@ -5,7 +5,7 @@ title "Google Speech Processing"
 ImageName "images/Voice-Recognition-Google-Cloud-speech-to-text.png"
  
 [right options]
-fileInput "Google key json file (required):" "Choose a file" FILE_INPUT None on None
+fileInput "Google key json file (required):" "Choose a file" KEY_FILE None on None
 toggleButton "" "Google speech processing" GOOGLE_PROCESS_INPUT True/False off ticked
 toggleButton "" "Google speech to text" GOOGLE_INPUT True/False on unticked
 dropdownList "Language of the speech:" "" LANGUAGE_SPEECH_INPUT en-US/it-IT/pt-PT/fr-FR/en-GB on None

--- a/demos/googleSpeechProcessing/main.yml
+++ b/demos/googleSpeechProcessing/main.yml
@@ -4,13 +4,13 @@ x-yarp-base: &yarp-base
   image: icubteamcode/speech:v2021.08.1-stable_master_sources
   environment:
     - YARP_FORWARD_LOG_ENABLE=1
-    - FILE_INPUT
+    - FILE_INPUT=${KEY_FILE}
     - LANGUAGE_SPEECH_INPUT
     - GOOGLE_PROCESS_INPUT
     - GOOGLE_INPUT
   volumes:
     - "${HOME}/${YARP_CONF_PATH}:/root/.config/yarp"
-    - "${FILE_INPUT_PATH}:/root/authorization"
+    - "${HOME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/key_folder:/root/authorization"
   networks:
     - hostnet
 

--- a/demos/googleVisionAI/composeGui.yml
+++ b/demos/googleVisionAI/composeGui.yml
@@ -7,12 +7,12 @@ x-yarp-base: &yarp-base
     - XAUTHORITY=/root/.Xauthority
     - YARP_FORWARD_LOG_ENABLE=1
     - YARP_ROBOT_NAME
-    - FILE_INPUT
+    - FILE_INPUT=${KEY_FILE}
   volumes:
     - "/tmp/.X11-unix:/tmp/.X11-unix"
     - "${XAUTHORITY}:/root/.Xauthority"
     - "${HOME}/${YARP_CONF_PATH}:/root/.config/yarp"
-    - "${FILE_INPUT_PATH}:/root/authorization"
+    - "${HOME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/key_folder:/root/authorization"
     - "/dev:/dev"
   network_mode: "host"
   privileged: true

--- a/demos/googleVisionAI/gui/gui_conf.ini
+++ b/demos/googleVisionAI/gui/gui_conf.ini
@@ -10,7 +10,7 @@ textEditButton "" "Custom image-streaming port" CUSTOM_PORT None on None
 fileInput "Google key json file (required):" "Choose a file" KEY_FILE None on None
 
 [Button hierarchy]
-Dependency - START_BUTTON - ( {FILE_INPUT selected enable} )
+Dependency - START_BUTTON - ( {KEY_FILE selected enable} )
 
 
 

--- a/demos/googleVisionAI/gui/gui_conf.ini
+++ b/demos/googleVisionAI/gui/gui_conf.ini
@@ -7,7 +7,7 @@ ImageName "images/googlevisionAI_small.jpeg"
 [right options]
 radioButton "" "robot cameras" RADIO_INPUT Robot on None
 textEditButton "" "Custom image-streaming port" CUSTOM_PORT None on None
-fileInput "Google key json file (required)" "Choose a file" FILE_INPUT None on None
+fileInput "Google key json file (required):" "Choose a file" KEY_FILE None on None
 
 [Button hierarchy]
 Dependency - START_BUTTON - ( {FILE_INPUT selected enable} )

--- a/demos/googleVisionAI/main.yml
+++ b/demos/googleVisionAI/main.yml
@@ -4,11 +4,11 @@ x-yarp-base: &yarp-base
   image: icubteamcode/google-vision:v2021.08.1-stable_master_sources
   environment:
     - YARP_FORWARD_LOG_ENABLE=1
-    - FILE_INPUT
+    - FILE_INPUT=${KEY_FILE}
     - CUSTOM_PORT
   volumes:
     - "${HOME}/${YARP_CONF_PATH}:/root/.config/yarp"
-    - "${FILE_INPUT_PATH}:/root/authorization"
+    - "${HOME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/key_folder:/root/authorization"
   networks:
     - hostnet
 

--- a/demos/speechToSpeech/composeGui.yml
+++ b/demos/speechToSpeech/composeGui.yml
@@ -8,7 +8,7 @@ x-yarp-base: &yarp-base
     - XAUTHORITY=/root/.Xauthority
     - YARP_FORWARD_LOG_ENABLE=1
     - YARP_ROBOT_NAME
-    - FILE_INPUT
+    - FILE_INPUT=${KEY_FILE}
     - LANGUAGE_INPUT
     - VOICE_NAME_INPUT
     - PULSE_SERVER=unix:${XDG_RUNTIME_DIR}/pulse/native
@@ -17,7 +17,7 @@ x-yarp-base: &yarp-base
     - "/tmp/.X11-unix:/tmp/.X11-unix"
     - "${XAUTHORITY}:/root/.Xauthority"
     - "${HOME}/${YARP_CONF_PATH}:/root/.config/yarp"
-    - "${FILE_INPUT_PATH}:/root/authorization"
+    - "${HOME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/key_folder:/root/authorization"
     - "${XDG_RUNTIME_DIR}/pulse/native:${XDG_RUNTIME_DIR}/pulse/native"
     - "~/.config/pulse/cookie:/root/.config/pulse/cookie"
     - "/dev:/dev"

--- a/demos/speechToSpeech/gui/gui_conf.ini
+++ b/demos/speechToSpeech/gui/gui_conf.ini
@@ -5,13 +5,13 @@ title "Google Parrot Application"
 ImageName "images/parrot.png"
  
 [right options]
-fileInput "Google key json file (required):" "Choose a file" FILE_INPUT None on None
+fileInput "Google key json file (required):" "Choose a file" KEY_FILE None on None
 dropdownList "Language of the speech:" "" LANGUAGE_INPUT en-US/it-IT/pt-PT/fr-FR/en-GB on None
 dropdownList "Voice types" "" VOICE_NAME_INPUT en-US-Wavenet-A/en-US-Wavenet-B/en-US-Wavenet-C/en-US-Wavenet-D/en-US-Wavenet-E/en-US-Wavenet-F/en-US-Wavenet-G/en-US-Wavenet-H/en-US-Wavenet-I/en-US-Wavenet-J on None
 audioInput "" "Try your voice!" AUDIO_INPUT ${HOME}/teamcode/appsAway/demos/speechToSpeech/gui/images/audioicon.png on None
 
 [Button hierarchy]
-Dependency - START_BUTTON - ( {FILE_INPUT selected enable} )
+Dependency - START_BUTTON - ( {KEY_FILE selected enable} )
 
 [Button Options]
 OptionList - VOICE_NAME_INPUT - LANGUAGE_INPUT [en-US/fr-FR/en-GB/pt-PT/it-IT] [[en-US-Wavenet-A/en-US-Wavenet-B/en-US-Wavenet-C/en-US-Wavenet-D/en-US-Wavenet-E/en-US-Wavenet-F/en-US-Wavenet-G/en-US-Wavenet-H/en-US-Wavenet-I/en-US-Wavenet-J],[fr-FR-Wavenet-A/fr-FR-Wavenet-B/fr-FR-Wavenet-C/fr-FR-Wavenet-D],[en-GB-Wavenet-A/en-GB-Wavenet-B/en-GB-Wavenet-C/en-GB-Wavenet-D],[pt-PT-Wavenet-A/pt-PT-Wavenet-B/pt-PT-Wavenet-C/pt-PT-Wavenet-D],[it-IT-Wavenet-A/it-IT-Wavenet-B/it-IT-Wavenet-C/it-IT-Wavenet-D]]

--- a/demos/speechToSpeech/main.yml
+++ b/demos/speechToSpeech/main.yml
@@ -7,15 +7,16 @@ x-yarp-base: &yarp-base
     - QT_X11_NO_MITSHM=1
     - XAUTHORITY=/root/.Xauthority
     - YARP_FORWARD_LOG_ENABLE=1
-    - FILE_INPUT
+    - FILE_INPUT=${KEY_FILE}
     - LANGUAGE_INPUT
     - GOOGLE_PROCESS_INPUT
     - VOICE_NAME_INPUT
+    - APPSAWAY_APP_PATH_NOT_CONSOLE
   volumes:
     - "/tmp/.X11-unix:/tmp/.X11-unix"
     - "${XAUTHORITY}:/root/.Xauthority"
     - "${HOME}/${YARP_CONF_PATH}:/root/.config/yarp"
-    - "${FILE_INPUT_PATH}:/root/authorization"
+    - "${HOME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/key_folder:/root/authorization"
   networks:
     - hostnet
 

--- a/demos/speechToText/composeGui.yml
+++ b/demos/speechToText/composeGui.yml
@@ -8,14 +8,14 @@ x-yarp-base: &yarp-base
     - XAUTHORITY=/root/.Xauthority
     - YARP_FORWARD_LOG_ENABLE=1
     - YARP_ROBOT_NAME
-    - FILE_INPUT
+    - FILE_INPUT=${KEY_FILE}
     - PULSE_SERVER=unix:${XDG_RUNTIME_DIR}/pulse/native
     - XDG_RUNTIME_DIR
   volumes:
     - "/tmp/.X11-unix:/tmp/.X11-unix"
     - "${XAUTHORITY}:/root/.Xauthority"
     - "${HOME}/${YARP_CONF_PATH}:/root/.config/yarp"
-    - "${FILE_INPUT_PATH}:/root/authorization"
+    - "${HOME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/key_folder:/root/authorization"
     - "${XDG_RUNTIME_DIR}/pulse/native:${XDG_RUNTIME_DIR}/pulse/native"
     - "~/.config/pulse/cookie:/root/.config/pulse/cookie"
     - "/dev:/dev"

--- a/demos/speechToText/gui/gui_conf.ini
+++ b/demos/speechToText/gui/gui_conf.ini
@@ -5,7 +5,7 @@ title "Google Speech to Text"
 ImageName "images/Voice-Recognition-Google-Cloud-speech-to-text.png"
  
 [right options]
-fileInput "Google key json file (required):" "Choose a file" FILE_INPUT None on None
+fileInput "Google key json file (required):" "Choose a file" KEY_FILE None on None
 dropdownList "Language of the speech:" "" LANGUAGE_SPEECH_INPUT en-US/it-IT/pt-PT/fr-FR/en-GB on None
 
 [Button hierarchy]

--- a/demos/speechToText/gui/gui_conf.ini
+++ b/demos/speechToText/gui/gui_conf.ini
@@ -9,4 +9,4 @@ fileInput "Google key json file (required):" "Choose a file" KEY_FILE None on No
 dropdownList "Language of the speech:" "" LANGUAGE_SPEECH_INPUT en-US/it-IT/pt-PT/fr-FR/en-GB on None
 
 [Button hierarchy]
-Dependency - START_BUTTON - ( {FILE_INPUT selected enable} )
+Dependency - START_BUTTON - ( {KEY_FILE selected enable} )

--- a/demos/speechToText/main.yml
+++ b/demos/speechToText/main.yml
@@ -4,12 +4,12 @@ x-yarp-base: &yarp-base
   image: icubteamcode/speech:v2021.08.1-stable_master_sources
   environment:
     - YARP_FORWARD_LOG_ENABLE=1
-    - FILE_INPUT
+    - FILE_INPUT=${KEY_FILE}
     - LANGUAGE_SPEECH_INPUT
     - GOOGLE_PROCESS_INPUT
   volumes:
     - "${HOME}/${YARP_CONF_PATH}:/root/.config/yarp"
-    - "${FILE_INPUT_PATH}:/root/authorization"
+    - "${HOME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/key_folder:/root/authorization"
   networks:
     - hostnet
 

--- a/demos/startQA/composeGui.yml
+++ b/demos/startQA/composeGui.yml
@@ -7,7 +7,7 @@ x-yarp-base: &yarp-base
     - XAUTHORITY=/root/.Xauthority
     - YARP_FORWARD_LOG_ENABLE=1
     - YARP_ROBOT_NAME
-    - FILE_INPUT
+    - FILE_INPUT=${KEY_FILE}
     - LANGUAGE_SYNTHESIS_INPUT
     - VOICE_NAME_INPUT
     - PULSE_SERVER=unix:${XDG_RUNTIME_DIR}/pulse/native
@@ -16,7 +16,7 @@ x-yarp-base: &yarp-base
     - "/tmp/.X11-unix:/tmp/.X11-unix"
     - "${XAUTHORITY}:/root/.Xauthority"
     - "${HOME}/${YARP_CONF_PATH}:/root/.config/yarp"
-    - "${FILE_INPUT_PATH}:/root/authorization"
+    - "${HOME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/key_folder:/root/authorization"
     - "${XDG_RUNTIME_DIR}/pulse/native:${XDG_RUNTIME_DIR}/pulse/native"
     - "~/.config/pulse/cookie:/root/.config/pulse/cookie"
     - "/dev:/dev"

--- a/demos/startQA/gui/gui_conf.ini
+++ b/demos/startQA/gui/gui_conf.ini
@@ -17,7 +17,7 @@ audioInput "" "Try your voice!" AUDIO_INPUT ${HOME}/teamcode/appsAway/demos/star
 Dependency - LANGUAGE_SYNTHESIS_INPUT - ( {GOOGLE_SYNTHESIS_INPUT selected enable} || {GOOGLE_INPUT selected enable} )
 Dependency - VOICE_NAME_INPUT - ( {GOOGLE_SYNTHESIS_INPUT selected enable} )
 Dependency - AUDIO_INPUT - ( {GOOGLE_SYNTHESIS_INPUT selected enable} )
-Dependency - START_BUTTON - ( {FILE_INPUT selected enable} && {START_ASK_INPUT selected enable} )
+Dependency - START_BUTTON - ( {KEY_FILE selected enable} && {START_ASK_INPUT selected enable} )
 
 
 [Button Options]

--- a/demos/startQA/gui/gui_conf.ini
+++ b/demos/startQA/gui/gui_conf.ini
@@ -5,7 +5,7 @@ title "START Question and Answer"
 ImageName "images/Voice-Recognition-Google-Cloud-speech-to-text.png"
  
 [right options]
-fileInput "Google key json file (required):" "Choose a file" FILE_INPUT None on None
+fileInput "Google key json file (required):" "Choose a file" KEY_FILE None on None
 dropdownList "Language of the speech:" "" LANGUAGE_SYNTHESIS_INPUT en-US/it-IT/pt-PT/fr-FR/en-GB on None
 toggleButton "" "Google speech to text" GOOGLE_INPUT True/False on unticked
 toggleButton "" "START Q&A" START_ASK_INPUT True/False off ticked

--- a/demos/startQA/main.yml
+++ b/demos/startQA/main.yml
@@ -4,7 +4,7 @@ x-yarp-base: &yarp-base
   image: icubteamcode/speech:v2021.08.1-stable_master_sources
   environment:
     - YARP_FORWARD_LOG_ENABLE=1
-    - FILE_INPUT
+    - FILE_INPUT=${KEY_FILE}
     - GOOGLE_INPUT
     #- LANGUAGE_SPEECH_INPUT
     - GOOGLE_PROCESS_INPUT
@@ -13,7 +13,7 @@ x-yarp-base: &yarp-base
     - VOICE_NAME_INPUT
   volumes:
     - "${HOME}/${YARP_CONF_PATH}:/root/.config/yarp"
-    - "${FILE_INPUT_PATH}:/root/authorization"
+    - "${HOME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/key_folder:/root/authorization"
   networks:
     - hostnet
 

--- a/demos/textToSpeech/composeGui.yml
+++ b/demos/textToSpeech/composeGui.yml
@@ -6,13 +6,13 @@ x-yarp-base: &yarp-base
     - PULSE_SERVER=unix:${XDG_RUNTIME_DIR}/pulse/native
     - YARP_FORWARD_LOG_ENABLE=1
     - YARP_ROBOT_NAME
-    - FILE_INPUT
+    - FILE_INPUT=${KEY_FILE}
     - LANGUAGE_SYNTHESIS_INPUT
     - VOICE_NAME_INPUT
     - XDG_RUNTIME_DIR
   volumes:
     - "${HOME}/${YARP_CONF_PATH}:/root/.config/yarp"
-    - "${FILE_INPUT_PATH}:/root/authorization"
+    - "${HOME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/key_folder:/root/authorization"
     - "${XDG_RUNTIME_DIR}/pulse/native:${XDG_RUNTIME_DIR}/pulse/native"
     - "~/.config/pulse/cookie:/root/.config/pulse/cookie"
     - "/dev:/dev"

--- a/demos/textToSpeech/gui/gui_conf.ini
+++ b/demos/textToSpeech/gui/gui_conf.ini
@@ -16,7 +16,7 @@ Dependency - VOICE_NAME_INPUT - ( {TEXT_INPUT selected enable} )
 Dependency - FILE_INPUT - ( {TEXT_INPUT selected enable} )
 Dependency - LANGUAGE_SYNTHESIS_INPUT - ( {TEXT_INPUT selected enable} )
 Dependency - AUDIO_INPUT - ( {TEXT_INPUT selected enable} )
-Dependency - START_BUTTON - ( {FILE_INPUT selected enable} && {TEXT_INPUT selected enable} )
+Dependency - START_BUTTON - ( {KEY_FILE selected enable} && {TEXT_INPUT selected enable} )
 
 
 [Button Options]

--- a/demos/textToSpeech/gui/gui_conf.ini
+++ b/demos/textToSpeech/gui/gui_conf.ini
@@ -5,7 +5,7 @@ title "Text to speech"
 ImageName "images/Voice-Recognition-Google-Cloud-speech-to-text.png"
  
 [right options]
-fileInput "Google key json file (required):" "Choose a file" FILE_INPUT None on None
+fileInput "Google key json file (required):" "Choose a file" KEY_FILE None on None
 toggleButton "" "Text-to-Speech" TEXT_INPUT True/False off ticked
 dropdownList "Language of the speech:" "" LANGUAGE_SYNTHESIS_INPUT en-US/it-IT/pt-PT/fr-FR/en-GB on None
 dropdownList "Voice types" "" VOICE_NAME_INPUT en-US-Wavenet-A/en-US-Wavenet-B/en-US-Wavenet-C/en-US-Wavenet-D/en-US-Wavenet-E/en-US-Wavenet-F/en-US-Wavenet-G/en-US-Wavenet-H/en-US-Wavenet-I/en-US-Wavenet-J on None

--- a/demos/textToSpeech/main.yml
+++ b/demos/textToSpeech/main.yml
@@ -4,12 +4,12 @@ x-yarp-base: &yarp-base
   image: icubteamcode/speech:v2021.08.1-stable_master_sources
   environment:
     - YARP_FORWARD_LOG_ENABLE=1
-    - FILE_INPUT
+    - FILE_INPUT=${KEY_FILE}
     - LANGUAGE_SYNTHESIS_INPUT
     - VOICE_NAME_INPUT
   volumes:
     - "${HOME}/${YARP_CONF_PATH}:/root/.config/yarp"
-    - "${FILE_INPUT_PATH}:/root/authorization"
+    - "${HOME}/${APPSAWAY_APP_PATH_NOT_CONSOLE}/key_folder:/root/authorization"
   networks:
     - hostnet
 

--- a/scripts/appsAway_copyFiles.sh
+++ b/scripts/appsAway_copyFiles.sh
@@ -127,13 +127,18 @@ init()
    exit_err "docker binary not found"
  fi
  if [ ! -f "${_APPSAWAY_ENV_FILE}" ]; then
-   exit_err "enviroment file ${_APPSAWAY_ENV_FILE} does not exists"
+   exit_err "enviroment file ${_APPSAWAY_ENV_FILE} does not exist"
  fi
  source ${_APPSAWAY_ENV_FILE}
+ if [ ! -f "${$APPSAWAY_APP_PATH}/${_DOCKER_ENV_FILE}" ]; then
+   exit_err "enviroment file ${_DOCKER_ENV_FILE} does not exist"
+ fi
+ source ${$APPSAWAY_APP_PATH}/${_DOCKER_ENV_FILE}
  os=`uname -s`
  if [ "$os" = "Darwin" ]
  then
   _ALL_LOCAL_IP_ADDRESSES=$(arp -a | awk -F'[()]' '{print $2}')
+  #' this is to solve the colors issue in code
  else
   _ALL_LOCAL_IP_ADDRESSES=$(hostname --all-ip-address)
   _ALL_LOCAL_IP_ADDRESSES+=$(hostname --all-fqdns)
@@ -465,6 +470,36 @@ copy_yarp_files()
   done
 }
 
+copy_key_file()
+{
+  if [ "$KEY_FILE" != "" ]
+  then
+    if [ ! -f "$KEY_FILE_PATH/$KEY_FILE" ]; then
+      exit_err "the key file $KEY_FILE you provided does not exist"
+    fi
+
+    # first we copy the key file into iCubApps
+    mkdir -p ${APPSAWAY_APP_PATH}/key_folder/
+    cp $KEY_FILE ${APPSAWAY_APP_PATH}/key_folder/
+
+    # then we copy it to all other machines
+    #iter=1
+    #List=$APPSAWAY_NODES_USERNAME_LIST
+    #set -- $List
+    #for node_ip in ${APPSAWAY_NODES_ADDR_LIST}
+    #do
+    #  if [ "$node_ip" != "$APPSAWAY_CONSOLENODE_ADDR" ]; then
+    #    username=$( eval echo "\$$iter")
+    #    log "copying key file on node $node_ip.."
+  #       scp_to_node ${APPSAWAY_APP_PATH}/key_folder/ ${username} ${node_ip} ${APPSAWAY_APP_PATH_NOT_CONSOLE}
+  #     fi
+  #     iter=$((iter+1))
+  #   done
+  else
+    error "KEY_FILE was not detected here"
+  fi
+}
+
 
 main()
 {
@@ -474,6 +509,7 @@ main()
   copy_yaml_files
 #  create_yarp_config_files
 #  create_env_file
+  copy_key_file
   copy_yarp_files
 }
 

--- a/scripts/appsAway_copyFiles.sh
+++ b/scripts/appsAway_copyFiles.sh
@@ -481,22 +481,6 @@ copy_key_file()
     # first we copy the key file into iCubApps
     mkdir -p ${APPSAWAY_APP_PATH}/key_folder/
     cp ${KEY_FILE_PATH}/${KEY_FILE} ${APPSAWAY_APP_PATH}/key_folder/
-
-    # then we copy it to all other machines
-    #iter=1
-    #List=$APPSAWAY_NODES_USERNAME_LIST
-    #set -- $List
-    #for node_ip in ${APPSAWAY_NODES_ADDR_LIST}
-    #do
-    #  if [ "$node_ip" != "$APPSAWAY_CONSOLENODE_ADDR" ]; then
-    #    username=$( eval echo "\$$iter")
-    #    log "copying key file on node $node_ip.."
-  #       scp_to_node ${APPSAWAY_APP_PATH}/key_folder/ ${username} ${node_ip} ${APPSAWAY_APP_PATH_NOT_CONSOLE}
-  #     fi
-  #     iter=$((iter+1))
-  #   done
-  else
-    error "KEY_FILE was not detected here"
   fi
 }
 

--- a/scripts/appsAway_copyFiles.sh
+++ b/scripts/appsAway_copyFiles.sh
@@ -130,10 +130,10 @@ init()
    exit_err "enviroment file ${_APPSAWAY_ENV_FILE} does not exist"
  fi
  source ${_APPSAWAY_ENV_FILE}
- if [ ! -f "${$APPSAWAY_APP_PATH}/${_DOCKER_ENV_FILE}" ]; then
+ if [ ! -f "${APPSAWAY_APP_PATH}/${_DOCKER_ENV_FILE}" ]; then
    exit_err "enviroment file ${_DOCKER_ENV_FILE} does not exist"
  fi
- source ${$APPSAWAY_APP_PATH}/${_DOCKER_ENV_FILE}
+ source ${APPSAWAY_APP_PATH}/${_DOCKER_ENV_FILE}
  os=`uname -s`
  if [ "$os" = "Darwin" ]
  then
@@ -480,7 +480,7 @@ copy_key_file()
 
     # first we copy the key file into iCubApps
     mkdir -p ${APPSAWAY_APP_PATH}/key_folder/
-    cp $KEY_FILE ${APPSAWAY_APP_PATH}/key_folder/
+    cp ${KEY_FILE_PATH}/${KEY_FILE} ${APPSAWAY_APP_PATH}/key_folder/
 
     # then we copy it to all other machines
     #iter=1


### PR DESCRIPTION
This PR allows for copying the Google authorization key from the console to any other machine in the cluster that may need it. Furthermore, the path for the key is now fixed since it is the new location of the file after copying.

All the ymls that use Google Services have been updated. This change has been tested in PARROT application and we could see it works well.