### PR TITLE
Removed HAND_VERSION from graspTheBall since not used

### DIFF
--- a/demos/graspTheBall/gui/gui_conf.ini
+++ b/demos/graspTheBall/gui/gui_conf.ini
@@ -7,9 +7,7 @@ ImageName "images/redball.jpg"
 [right options]
 toggleButton "" "Calibrate Color" CALIB_COLOR true/false on unticked
 toggleButton "" "Calibrate Offsets" CALIB_OFFSETS true/false on unticked
-dropdownList "Hand version:" "" HAND_VERSION V1_3/V2/V2_1 off None
 dropdownList "Arm to calibrate:" "" ARM left/right/both off None
 
 [Button hierarchy]
-Dependency - HAND_VERSION - ( {CALIB_OFFSETS selected enable} )
 Dependency - ARM - ( {CALIB_OFFSETS selected enable} )

--- a/demos/graspTheBall/main.yml
+++ b/demos/graspTheBall/main.yml
@@ -6,7 +6,6 @@ x-yarp-base: &yarp-base
     - YARP_FORWARD_LOG_ENABLE=1
     - CALIB_COLOR
     - CALIB_OFFSETS
-    - HAND_VERSION
     - ARM
     - YARP_ROBOT_NAME
   volumes:


### PR DESCRIPTION
In this PR, the GUI option to choose the version of the hand has been removed from `graspTheBall` since not used by our deployment. Consequently, the `ymls` have been updated with this change.