### PR TITLE
Add release workflow triggered by code

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+    repository_dispatch:
+        types: [code_trigger]
+
+jobs:
+  build:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Get Token
+        id: get_workflow_token
+        uses: tibdex/github-app-token@v1
+        with:
+          private_key: ${{ secrets.ICUB_TECH_CODE_KEY }}
+          app_id: ${{ secrets.ICUB_TECH_CODE_ID }}
+          repository: icub-tech-iit/code
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ steps.get_workflow_token.outputs.token }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ github.event.client_payload.version }}
+          release_name: AppsAway ${{ github.event.client_payload.version }}
+          body: |
+            Release ${{ github.event.client_payload.version }}
+          draft: false
+          prerelease: false


### PR DESCRIPTION
This creates a release of appsAway with the same tag of the latest superbuild released