### PR TITLE
check for machines with nvidia gpus to install the correct configuration

### DIFF
--- a/scripts/ansible_setup/setup_hosts_ini.sh
+++ b/scripts/ansible_setup/setup_hosts_ini.sh
@@ -27,20 +27,18 @@ do
      echo "${nodes_name_array[$i]}" >> ./hosts.ini
 done 
 echo "" >> ./hosts.ini
-if [[ $APPSAWAY_CUDANODE_ADDR != "" ]] ; then
-    echo "[cuda:children]" >> ./hosts.ini
-    for (( i=0; i<$nodes_len; i++ )) 
-    do  
-        username=${nodes_usr_array[$i]}
-        node=${nodes_addr_array[$i]}
-        _IS_CUDA=$( echo "${nodes_name_array[$i]}" | grep "icubcuda" )
-        _HAS_GPU=$( ${_SSH_BIN} ${_SSH_PARAMS} $username@$node "lshw -C display" | grep NVIDIA || true)
-        if [[ $_IS_CUDA != "" ]] || [[ $_HAS_GPU != "" ]]; then
-            echo "${nodes_name_array[$i]}" >> ./hosts.ini
-        fi
-    done 
-    echo "" >> ./hosts.ini
-fi
+echo "[cuda:children]" >> ./hosts.ini
+for (( i=0; i<$nodes_len; i++ )) 
+do  
+    username=${nodes_usr_array[$i]}
+    node=${nodes_addr_array[$i]}
+    _IS_CUDA=$( echo "${nodes_name_array[$i]}" | grep "icubcuda" )
+    _HAS_GPU=$( ${_SSH_BIN} ${_SSH_PARAMS} $username@$node "lshw -C display" | grep NVIDIA || true)
+    if [[ $_IS_CUDA != "" ]] || [[ $_HAS_GPU != "" ]]; then
+        echo "${nodes_name_array[$i]}" >> ./hosts.ini
+    fi
+done 
+echo "" >> ./hosts.ini
 
 # now we populate each node
 for (( i=0; i<$nodes_len; i++ ))

--- a/scripts/appsAway_checkDocker.sh
+++ b/scripts/appsAway_checkDocker.sh
@@ -87,7 +87,8 @@ check_docker_version() {
         _DOCKER_NAMES_LIST="$_DOCKER_NAMES_LIST ${nodes_name_array[$iter]}"
       fi
       _IS_CUDA=$( echo ${nodes_name_array[$iter]} | grep 'icubcuda' || true)
-      if [[ $_IS_CUDA != "" ]] ; then
+      _HAS_GPU=$( ${_SSH_BIN} ${_SSH_PARAMS} $username@$node "lshw -C display" | grep NVIDIA || true)
+      if [[ $_IS_CUDA != "" ]] || [[ $_HAS_GPU != "" ]]; then
         _OUTPUT=$(${_SSH_BIN} ${_SSH_PARAMS} $username@$node "nvidia-docker --version 2>&1" | grep 'Docker version' || true)
         if [[ $_OUTPUT == "" ]] ; then
           # ADD THIS NODE TO THE HOSTS_CUDA.INI
@@ -140,7 +141,7 @@ populate_hosts() {
       echo "[cuda:children]" >> ./$file_name
       for (( i=0; i<$array_len; i++ )) 
       do  
-        _IS_CUDA=$( echo "${name_array[$i]}" | grep "icubcuda" )
+        _IS_CUDA=${name_array[$i]}
         if [[ $_IS_CUDA != "" ]] ; then
             echo "${name_array[$i]}" >> ./$file_name
         fi


### PR DESCRIPTION
This PR introduces a new check in the `ansible` step, where we check if a machine has an NVIDIA GPU using `lshw -C display`.

If a  GPU is detected, we add the machine to the list of hosts that require a `cuda` configuration, which installs `nvidia-docker2` and sets the correct configuration of ``/etc/docker/daemon.json`.

With this, in machines that use the GPU as a display device, we can use them as `icubgui` machines without any other changes in deployment or images.