### PR TITLE
now checkRobotInterface is compatible with yarp 3.7

### DIFF
--- a/modules/checkRobotInterface/src/main.cpp
+++ b/modules/checkRobotInterface/src/main.cpp
@@ -48,7 +48,7 @@ int main(int argc, char *argv[])
     ResourceFinder rf;
     rf.configure(argc, argv);
     std::string robotName=rf.find("robot").asString();
-    double conn_timeout=rf.find("timeout").asDouble();
+    double conn_timeout=rf.find("timeout").asFloat64();
     
     if(robotName=="")
         robotName=default_robotName;


### PR DESCRIPTION
I substituted `asDouble()` method in favour of `asFloat64()`  in order to make `checkRobotInterface` compatible with YARP version 3.7.

See [here](https://github.com/robotology/yarp/releases/tag/v3.7.0).

I compiled `checkRobotInterface` without any error.