### PR TITLE
iCubTest: remove docker visualizer

### DIFF
--- a/demos/iCubTest/main.yml
+++ b/demos/iCubTest/main.yml
@@ -28,19 +28,6 @@ services:
 
 #------------------------------------------------------------------------------------------------
 
-
-
-  #use network.peer ip address and port 8080 to see the containers status in browser (http://localhost:8080/)
-  visualizer:
-    image: dockersamples/visualizer:stable
-    ports:
-      - "8080:8080"
-    volumes:
-      - "/var/run/docker.sock:/var/run/docker.sock"
-    deploy:
-      placement:
-        constraints: [node.role == manager]
-
 networks:
   hostnet:
     external: true


### PR DESCRIPTION
As discussed some time ago with @vvasco, we were thinking of removing the **docker visualizer** (which we are not using now) from the deployment. When included, this makes the procedure of selecting images from the website less intuitive, forcing the user to use **advanced settings** menu.