### PR TITLE
Changed the way we call yarprobotinterface in the deployment

### DIFF
--- a/demos/blenderController/composeHead.yml
+++ b/demos/blenderController/composeHead.yml
@@ -20,6 +20,7 @@ services:
     <<: *yarp-head
     devices:
       - "/dev/bosch-i2c-imu:/dev/bosch-i2c-imu"
-    command: sh -c "if [ -f "/root/.config/yarp/yarp_namespace.conf" ]; then yarp wait $$(echo $$(cat /root/.config/yarp/yarp_namespace.conf)); else yarp wait /root; fi; yarprobotinterface"
+    restart: on-failure
+    command: yarprobotinterface
 
 

--- a/demos/demoTemplate/composeHead.yml.template
+++ b/demos/demoTemplate/composeHead.yml.template
@@ -17,8 +17,9 @@ services:
 # This is an example for running yarprobotinterface in the container
   yrobotinterface:
     <<: *yarp-head
-    devices: 
+    devices:
       - "/dev/bosch-i2c-imu:/dev/bosch-i2c-imu"
+    restart: on-failure
     command: yarprobotinterface
 
 #################################### ADD YOUR SERVICES HERE #####################################

--- a/demos/graspTheBall/composeHead.yml
+++ b/demos/graspTheBall/composeHead.yml
@@ -20,7 +20,8 @@ services:
     <<: *yarp-head
     devices:
       - "/dev/bosch-i2c-imu:/dev/bosch-i2c-imu"
-    command: sh -c "if [ -f "/root/.config/yarp/yarp_namespace.conf" ]; then yarp wait $$(echo $$(cat /root/.config/yarp/yarp_namespace.conf)); else yarp wait /root; fi; yarprobotinterface"
+    restart: on-failure
+    command: yarprobotinterface
 
   yGrabberCameras:
     <<: *yarp-head

--- a/demos/iCubTest/composeHead.yml
+++ b/demos/iCubTest/composeHead.yml
@@ -20,6 +20,7 @@ services:
     <<: *yarp-head
     devices: 
       - "/dev/bosch-i2c-imu:/dev/bosch-i2c-imu"
+    restart: on-failure
     command: yarprobotinterface
 
 

--- a/demos/robotBaseStartup/composeHead.yml
+++ b/demos/robotBaseStartup/composeHead.yml
@@ -20,6 +20,7 @@ services:
     <<: *yarp-head
     devices: 
       - "/dev/bosch-i2c-imu:/dev/bosch-i2c-imu"
+    restart: on-failure
     command: yarprobotinterface
 
 

--- a/demos/superviseCalib/composeHead.yml
+++ b/demos/superviseCalib/composeHead.yml
@@ -28,7 +28,8 @@ services:
     <<: *yarp-head
     devices: 
       - "/dev/bosch-i2c-imu:/dev/bosch-i2c-imu"
-    command: sh -c "if [ -f "/root/.config/yarp/yarp_namespace.conf" ]; then yarp wait $$(echo $$(cat /root/.config/yarp/yarp_namespace.conf)); else yarp wait /root; fi; yarprobotinterface"
+    restart: on-failure
+    command: yarprobotinterface
 
 
 

--- a/demos/yarpOpenFace/composeHead.yml
+++ b/demos/yarpOpenFace/composeHead.yml
@@ -21,6 +21,7 @@ services:
     <<: *yarp-head
     devices: 
       - "/dev/bosch-i2c-imu:/dev/bosch-i2c-imu"
+    restart: on-failure
     command: yarprobotinterface
 
   yGrabberCameras:


### PR DESCRIPTION
This PR changes the way we call `yarprobotinterface` in our deployment. Wrapping it in a shell command like we do now prevents the program from closing properly. 

To allow for proper cleanup of the program we put `yarprobotinterface` as the only command in the service. To still allow the system to wait for yarp, and to remain resilent to eventual issues, we added a restart policy of `on-failure`, so that the service is open as soon as th external conditions allow it. 

This has been tested with `iCubTest` and the results were satisfactory.